### PR TITLE
Update the JSMA docstring to clarify that it can take both logits and softmax outputs

### DIFF
--- a/tutorials/mnist_tutorial_jsma.py
+++ b/tutorials/mnist_tutorial_jsma.py
@@ -112,6 +112,14 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     grid_shape = (nb_classes, nb_classes, img_rows, img_cols, channels)
     grid_viz_data = np.zeros(grid_shape, dtype='f')
 
+    # by default, we have softmax after a CNN, remove it here
+    # JSMA takes the the logits, pre-softmax
+    model.layers.pop()
+    last = model.layers[-1]
+    last.outbound_nodes = []
+    model.outputs = [last.output]
+    model.built = False
+
     # Instantiate a SaliencyMapMethod attack object
     jsma = SaliencyMapMethod(model, back='tf', sess=sess)
     jsma_params = {'theta': 1., 'gamma': 0.1,


### PR DESCRIPTION
JSMA is implemented at the logit layer, pre-softmax. However, the tutorial implements it after the softmax. Add some (keras-specific) code to remove the last softmax layer.