### PR TITLE
enable user to append a dictionary to the feed_dict before sess.run

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -277,7 +277,8 @@ def tf_model_load(sess):
     return True
 
 
-def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, feed=None, args=None):
+def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, feed=None,
+               args=None):
     """
     A helper function that computes a tensor on numpy inputs by batches.
 

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -93,7 +93,7 @@ def tf_model_train(*args, **kwargs):
 
 def model_train(sess, x, y, predictions, X_train, Y_train, save=False,
                 predictions_adv=None, init_all=True, evaluate=None,
-                verbose=True, args=None):
+                verbose=True, feed=None, args=None):
     """
     Train a TF graph
     :param sess: TF session to use when training the graph
@@ -111,6 +111,9 @@ def model_train(sess, x, y, predictions, X_train, Y_train, save=False,
     :param evaluate: function that is run after each training iteration
                      (typically to display the test/validation accuracy).
     :param verbose: (boolean) all print statements disabled when set to False.
+    :param feed: An optional dictionary that is appended to the feeding
+                 dictionary before the session runs. Can be used to feed
+                 the learning phase of a Keras model for instance.
     :param args: dict or argparse `Namespace` object.
                  Should contain `nb_epochs`, `learning_rate`,
                  `batch_size`
@@ -164,8 +167,10 @@ def model_train(sess, x, y, predictions, X_train, Y_train, save=False,
                     batch, len(X_train), args.batch_size)
 
                 # Perform one training step
-                train_step.run(feed_dict={x: X_train[start:end],
-                                          y: Y_train[start:end]})
+                feed_dict = {x: X_train[start:end], y: Y_train[start:end]}
+                if feed is not None:
+                    feed_dict.update(feed)
+                train_step.run(feed_dict=feed_dict)
             assert end >= len(X_train)  # Check that all examples were used
             cur = time.time()
             if verbose:
@@ -191,7 +196,7 @@ def tf_model_eval(*args, **kwargs):
     return model_eval(*args, **kwargs)
 
 
-def model_eval(sess, x, y, model, X_test, Y_test, args=None):
+def model_eval(sess, x, y, model, X_test, Y_test, feed=None, args=None):
     """
     Compute the accuracy of a TF model on some data
     :param sess: TF session to use when training the graph
@@ -200,6 +205,9 @@ def model_eval(sess, x, y, model, X_test, Y_test, args=None):
     :param model: model output predictions
     :param X_test: numpy array with training inputs
     :param Y_test: numpy array with training outputs
+    :param feed: An optional dictionary that is appended to the feeding
+             dictionary before the session runs. Can be used to feed
+             the learning phase of a Keras model for instance.
     :param args: dict or argparse `Namespace` object.
                  Should contain `batch_size`
     :return: a float with the accuracy value
@@ -238,9 +246,10 @@ def model_eval(sess, x, y, model, X_test, Y_test, args=None):
 
             # The last batch may be smaller than all others, so we need to
             # account for variable batch size here
-            cur_acc = acc_value.eval(
-                feed_dict={x: X_test[start:end],
-                           y: Y_test[start:end]})
+            feed_dict = {x: X_test[start:end], y: Y_test[start:end]}
+            if feed is not None:
+                feed_dict.update(feed)
+            cur_acc = acc_value.eval(feed_dict=feed_dict)
 
             accuracy += (cur_batch_size * cur_acc)
 
@@ -268,7 +277,7 @@ def tf_model_load(sess):
     return True
 
 
-def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, args=None):
+def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, feed=None, args=None):
     """
     A helper function that computes a tensor on numpy inputs by batches.
 
@@ -276,6 +285,9 @@ def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, args=None):
     :param tf_inputs:
     :param tf_outputs:
     :param numpy_inputs:
+    :param feed: An optional dictionary that is appended to the feeding
+             dictionary before the session runs. Can be used to feed
+             the learning phase of a Keras model for instance.
     :param args: dict or argparse `Namespace` object.
                  Should contain `batch_size`
     """
@@ -309,6 +321,8 @@ def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, args=None):
                 assert e.shape[0] == cur_batch_size
 
             feed_dict = dict(zip(tf_inputs, numpy_input_batches))
+            if feed is not None:
+                feed_dict.update(feed)
             numpy_output_batches = sess.run(tf_outputs, feed_dict=feed_dict)
             for e in numpy_output_batches:
                 assert e.shape[0] == cur_batch_size, e.shape
@@ -321,16 +335,21 @@ def batch_eval(sess, tf_inputs, tf_outputs, numpy_inputs, args=None):
     return out
 
 
-def model_argmax(sess, x, predictions, samples):
+def model_argmax(sess, x, predictions, samples, feed=None):
     """
     Helper function that computes the current class prediction
     :param sess: TF session
     :param x: the input placeholder
     :param predictions: the model's symbolic output
     :param samples: numpy array with input samples (dims must match x)
+    :param feed: An optional dictionary that is appended to the feeding
+             dictionary before the session runs. Can be used to feed
+             the learning phase of a Keras model for instance.
     :return: the argmax output of predictions, i.e. the current predicted class
     """
     feed_dict = {x: samples}
+    if feed is not None:
+        feed_dict.update(feed)
     probabilities = sess.run(predictions, feed_dict)
 
     if samples.shape[0] == 1:


### PR DESCRIPTION
Closes #142

Allows users to pass an optional dictionary mapping placeholders to values that is added to feed_dict in utils_tf methods (training, eval, batch_eval)

Useful when the model depends on additional placeholders that need to be fed a value. This is the case in graphs defined with Keras: they need to be fed with a value for the learning phase. This will for instance give back support for dropout layers (currently disabled in the tutorials).