### PR TITLE
prefix /private to working dir for Mac OS X users

### DIFF
--- a/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh
+++ b/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh
@@ -16,7 +16,11 @@ MAX_EPSILON=16
 # Prepare working directory and copy all necessary files.
 # In particular copy attacks defenses and dataset, so originals won't
 # be overwritten.
-WORKING_DIR=$(mktemp -d)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	WORKING_DIR="/private"$(mktemp -d)
+else
+	WORKING_DIR=$(mktemp -d)
+fi
 echo "Preparing working directory: ${WORKING_DIR}"
 mkdir "${WORKING_DIR}/attacks"
 mkdir "${WORKING_DIR}/targeted_attacks"

--- a/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh
+++ b/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh
@@ -16,7 +16,7 @@ MAX_EPSILON=16
 # Prepare working directory and copy all necessary files.
 # In particular copy attacks defenses and dataset, so originals won't
 # be overwritten.
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "${OSTYPE}" == "darwin"* ]]; then
     WORKING_DIR="/private"$(mktemp -d)
 else
     WORKING_DIR=$(mktemp -d)

--- a/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh
+++ b/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh
@@ -17,9 +17,9 @@ MAX_EPSILON=16
 # In particular copy attacks defenses and dataset, so originals won't
 # be overwritten.
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	WORKING_DIR="/private"$(mktemp -d)
+    WORKING_DIR="/private"$(mktemp -d)
 else
-	WORKING_DIR=$(mktemp -d)
+    WORKING_DIR=$(mktemp -d)
 fi
 echo "Preparing working directory: ${WORKING_DIR}"
 mkdir "${WORKING_DIR}/attacks"


### PR DESCRIPTION
Executing [run_attacks_and_defenses.sh](https://github.com/tensorflow/cleverhans/blob/master/examples/nips17_adversarial_competition/run_attacks_and_defenses.sh) directly on my Mac OS X results in a 'Mounts denied' error. This has been discussed and resolved [here on Stack Overflow](https://stackoverflow.com/questions/45122459/docker-mounts-denied-the-paths-are-not-shared-from-os-x-and-are-not-known/45123074#45123074). Proposing an elementary fix so that the script can be used by Mac users directly.