### PR TITLE
allow running the JSMA with extra feed dict params

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -108,13 +108,12 @@ class Attack(object):
                           "structural paramaters is inefficient and should"
                           " be avoided. Calling generate() is preferred.")
 
-    def generate_np(self, x_val, feed=None, **kwargs):
+    def generate_np(self, x_val, **kwargs):
         """
         Generate adversarial examples and return them as a Numpy array.
         Sub-classes *should not* implement this method unless they must
         perform special handling of arguments.
         :param x_val: A Numpy array with the original inputs.
-        :param feed: optional extra feed parameters for tensorflow
         :param **kwargs: optional parameters used by child classes.
         :return: A Numpy array holding the adversarial examples.
         """
@@ -161,9 +160,6 @@ class Attack(object):
 
         for name in feedable:
             feed_dict[new_kwargs[name]] = feedable[name]
-
-        if feed is not None:
-            feed_dict.update(feed)
 
         return self.sess.run(x_adv, feed_dict)
 
@@ -405,7 +401,7 @@ class SaliencyMapMethod(Attack):
         self.structural_kwargs = ['theta', 'gamma', 'nb_classes',
                                   'clip_max', 'clip_min']
 
-    def generate(self, x, feed=None, **kwargs):
+    def generate(self, x, **kwargs):
         """
         Generate symbolic graph for adversarial examples and return.
         :param x: The model's symbolic inputs.
@@ -416,7 +412,6 @@ class SaliencyMapMethod(Attack):
         :param clip_min: (optional float) Minimum component value for clipping
         :param clip_max: (optional float) Maximum component value for clipping
         :param targets: (optional) Target tensor if the attack is targeted
-        :param feed: (optional) extra feed parameters for tensorflow
         """
         import tensorflow as tf
         from .attacks_tf import jacobian_graph, jsma_batch
@@ -434,7 +429,7 @@ class SaliencyMapMethod(Attack):
                 return jsma_batch(self.sess, x, preds, grads, x_val,
                                   self.theta, self.gamma, self.clip_min,
                                   self.clip_max, self.nb_classes,
-                                  targets=targets, feed=feed)
+                                  targets=targets)
 
             # Attack is targeted, target placeholder will need to be fed
             wrap = tf.py_func(jsma_wrap, [x, self.targets], tf.float32)
@@ -443,7 +438,7 @@ class SaliencyMapMethod(Attack):
                 return jsma_batch(self.sess, x, preds, grads, x_val,
                                   self.theta, self.gamma, self.clip_min,
                                   self.clip_max, self.nb_classes,
-                                  targets=None, feed=feed)
+                                  targets=None)
 
             # Attack is untargeted, target values will be chosen at random
             wrap = tf.py_func(jsma_wrap, [x], tf.float32)
@@ -451,7 +446,7 @@ class SaliencyMapMethod(Attack):
         return wrap
 
     def parse_params(self, theta=1., gamma=np.inf, nb_classes=10, clip_min=0.,
-                     clip_max=1., targets=None, feed=None, **kwargs):
+                     clip_max=1., targets=None, **kwargs):
         """
         Take in a dictionary of parameters and applies attack-specific checks
         before saving them as attributes.
@@ -610,7 +605,7 @@ def vatm(model, x, logits, eps, back='tf', num_iterations=1, xi=1e-6,
 
 
 def jsma(sess, x, predictions, grads, sample, target, theta, gamma=np.inf,
-         increase=True, back='tf', clip_min=None, clip_max=None, feed=None):
+         increase=True, back='tf', clip_min=None, clip_max=None):
     """
     A wrapper for the Jacobian-based saliency map approach.
     It calls the right function, depending on the
@@ -631,7 +626,6 @@ def jsma(sess, x, predictions, grads, sample, target, theta, gamma=np.inf,
                     value for components of the example returned
     :param clip_max: optional parameter that can be used to set a maximum
                     value for components of the example returned
-    :param feed: optional parameter for passing extra feed_dict values to TF
     :return: an adversarial sample
     """
     warnings.warn("attacks.jsma is deprecated and will be removed on "
@@ -640,6 +634,6 @@ def jsma(sess, x, predictions, grads, sample, target, theta, gamma=np.inf,
         # Compute Jacobian-based saliency map attack using TensorFlow
         from .attacks_tf import jsma
         return jsma(sess, x, predictions, grads, sample, target, theta, gamma,
-                    clip_min, clip_max, feed=feed)
+                    clip_min, clip_max)
     elif back == 'th':
         raise NotImplementedError("Theano jsma not implemented.")

--- a/tests_tf/test_attacks_tf.py
+++ b/tests_tf/test_attacks_tf.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import unittest
+import tensorflow as tf
+import tensorflow.contrib.slim as slim
+
+from cleverhans import attacks_tf
+
+class TestAttacksTF(unittest.TestCase):
+    def test_jsma_batch_with_feed(self):
+        with tf.Session() as sess:
+            X = np.random.rand(1, 13)
+
+            # construct a simple graph that will require extra placeholders
+            x = tf.placeholder('float', shape=(None, 13))
+            b = tf.placeholder('bool')
+            logits = slim.dropout(slim.fully_connected(x, 10),
+                                  is_training=b)
+
+            sess.run(tf.global_variables_initializer())
+            
+            # jsma should work without generating an error
+            jacobian = attacks_tf.jacobian_graph(logits, x, 10)
+            attacks_tf.jsma_batch(sess, x, logits, jacobian, X, theta=1.,
+                                  gamma=0.25, clip_min=0, clip_max=1,
+                                  nb_classes=10, feed={b: False})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This should let users run JSMA attacks (and all others using generate_np) on models that require more `feed_dict` parameters than just inputs.

Note: I'm using the attacks_tf helpers rather than the abstract attacks interface since it doesn't seem to be compatible with the rest of my code, so I only added a test for that case, but it might be good to add more tests to verify it works with the main interface.