### PR TITLE
Fixes ex_cifar10_tf.py by changing learning rate from 0.1 to 0.001

### DIFF
--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -22,7 +22,7 @@ flags.DEFINE_string('train_dir', '/tmp', 'Directory storing the saved model.')
 flags.DEFINE_string('filename', 'cifar10.ckpt', 'Filename to save model under.')
 flags.DEFINE_integer('nb_epochs', 10, 'Number of epochs to train model')
 flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
-flags.DEFINE_float('learning_rate', 0.1, 'Learning rate for training')
+flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
 
 
 def data_cifar10():


### PR DESCRIPTION
I tried running ex_cifar10_tf.py and noticed that the model was not learning.  That is, the printed test accuracy did not change from epoch to epoch.  Changing the learning rate from 0.1 to 0.001 appears to fix the problem.  Note, 0.001 is the learning rate used in the MNIST tutorials.