### PR TITLE
Update checkpoint location for adversarially trained ImageNet models

### DIFF
--- a/examples/nips17_adversarial_competition/sample_defenses/download_checkpoints.sh
+++ b/examples/nips17_adversarial_competition/sample_defenses/download_checkpoints.sh
@@ -14,13 +14,13 @@ rm inception_v3_2016_08_28.tar.gz
 # Download adversarially trained inception v3 checkpoint
 # into adv_inception_v3 subdirectory
 cd "${SCRIPT_DIR}/adv_inception_v3/"
-wget https://storage.googleapis.com/nips17-adversarial-competition-baselines/adv_inception_v3_2017_08_18.tar.gz
+wget http://download.tensorflow.org/models/adv_inception_v3_2017_08_18.tar.gz
 tar -xvzf adv_inception_v3_2017_08_18.tar.gz
 rm adv_inception_v3_2017_08_18.tar.gz
 
 # Download ensemble adversarially trained inception resnet v2 checkpoint
 # into ens_adv_inception_resnet_v2 subdirectory
 cd "${SCRIPT_DIR}/ens_adv_inception_resnet_v2/"
-wget https://storage.googleapis.com/nips17-adversarial-competition-baselines/ens_adv_inception_resnet_v2_2017_08_18.tar.gz
+wget http://download.tensorflow.org/models/ens_adv_inception_resnet_v2_2017_08_18.tar.gz
 tar -xvzf ens_adv_inception_resnet_v2_2017_08_18.tar.gz
 rm ens_adv_inception_resnet_v2_2017_08_18.tar.gz


### PR DESCRIPTION
Adversarially trained imagenet models are uploaded to downloads.tensorflow.org, so updating checkpoint locations accordingly