### PR TITLE
Update batch size in validate_submission_lib

### DIFF
--- a/examples/nips17_adversarial_competition/validation_tool/validate_submission_lib.py
+++ b/examples/nips17_adversarial_competition/validation_tool/validate_submission_lib.py
@@ -31,7 +31,7 @@ REQUIRED_METADATA_JSON_FIELDS = ['entry_point', 'container',
 
 CMD_VARIABLE_RE = re.compile('^\\$\\{(\\w+)\\}$')
 
-BATCH_SIZE = 8
+BATCH_SIZE = 100
 IMAGE_NAME_PATTERN = 'IMG{0:04}.png'
 
 ALLOWED_EPS = [4, 8, 12, 16]


### PR DESCRIPTION
Change batch size in submission validation tool to 100 to mimic the situation of a real evaluation when submission is evaluated on 100 images at a time.