### PR TITLE
Update readme to point at sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ The `examples/` folder contains additional scripts to showcase different uses
 of the CleverHans library or get you started competing in different adversarial
 example contests.
 
+## List of attacks
+
+You can find a full list attacks along with their function signatures at [cleverhans.readthedocs.io](http://cleverhans.readthedocs.io/)
+
+
+
 ## Reporting benchmarks
 
 When reporting benchmarks, please:

--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ example contests.
 
 You can find a full list attacks along with their function signatures at [cleverhans.readthedocs.io](http://cleverhans.readthedocs.io/)
 
-
-
 ## Reporting benchmarks
 
 When reporting benchmarks, please:


### PR DESCRIPTION
The linked readthedocs url is not currently built, however it builds correctly locally and on my personal fork of this repo.

If webhooks are properly configured, merging this PR should also trigger a sphynx build at http://cleverhans.readthedocs.io/

After checks pass, I plan to merge this in.