### PR TITLE
fix checksum when tutorials and examples folder is absent

### DIFF
--- a/cleverhans/devtools/list_files.py
+++ b/cleverhans/devtools/list_files.py
@@ -33,14 +33,20 @@ def list_files(suffix=""):
     file_list = _list_files(cleverhans_path, suffix)
 
     tutorials_path = os.path.join(repo_path, "cleverhans_tutorials")
-    tutorials_files = _list_files(tutorials_path, suffix)
-    tutorials_files = [os.path.join(os.pardir, path) for path in
-                       tutorials_files]
-    examples_path = os.path.join(repo_path, "examples")
-    examples_files = _list_files(examples_path, suffix)
-    examples_files = [os.path.join(os.pardir, path) for path in
-                      examples_files]
+    if os.path.isdir(tutorials_path):
+        tutorials_files = _list_files(tutorials_path, suffix)
+        tutorials_files = [os.path.join(os.pardir, path) for path in
+                           tutorials_files]
+    else:
+        tutorials_files = []
 
+    examples_path = os.path.join(repo_path, "examples")
+    if os.path.isdir(examples_path):
+        examples_files = _list_files(examples_path, suffix)
+        examples_files = [os.path.join(os.pardir, path) for path in
+                          examples_files]
+    else:
+        examples_files = []
     file_list = file_list + tutorials_files + examples_files
 
     return file_list


### PR DESCRIPTION
This is a fix for the version number bug encountered when the tutorials or examples folders is missing from the user's clone of the repository. This is the case for the google mirror of the repository.