### PR TITLE
PGD Targeted Attack fix

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -1203,7 +1203,9 @@ class MadryEtAl(Attack):
         eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps)
         eta = clip_eta(eta, self.ord, self.eps)
 
-        if self.y is not None:
+        if self.y_target is not None:
+            y = self.y_target
+        elif self.y is not None:
             y = self.y
         else:
             preds = self.model.get_probs(x)


### PR DESCRIPTION
Quick fix for executing Madry PGD in the targeted case. 

Quick question: As proposed in the 'Delving into Transferable Adversarial Examples' paper, executing attacks on an ensemble models normally generates more readily transferable adversarial examples. For some tests I'm doing, I've modified the Cleverhans attacks I've been using to rather than attack a single model, attack a list of models. Therefore, if you wanted to execute a simple attack on a single model, you would pass that model in as a one-element list. 

Would this code be of interest to be integrated into Cleverhans? More generally, I do think code which makes it easier to perform attacks on an ensemble of models should be integrated. 