### PR TITLE
Fix softmax identification in model_loss

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -30,7 +30,7 @@ def model_loss(y, model, mean=True):
     """
 
     op = model.op
-    if "softmax" in str(op).lower():
+    if "softmax" in str(op).lower() and "pre_softmax" not in str(op).lower():
         logits, = op.inputs
     else:
         logits = model


### PR DESCRIPTION
model_loss determines softmax by looking for the string 'softmax' in the inputs to the tensor. Inception (and others) uses 'pre_softmax' for the logits, breaking it. This is a specific workaround for those default models.