### PR TITLE
Tighten mnist tutorial tests

### DIFF
--- a/tests_tf/test_mnist_tutorial_tf.py
+++ b/tests_tf/test_mnist_tutorial_tf.py
@@ -43,10 +43,10 @@ class TestMNISTTutorialTF(CleverHansTest):
                          atol=atol_fac * 5e-3)
         self.assertClose(report.train_adv_train_clean_eval,
                          report_2.train_adv_train_clean_eval,
-                         atol=atol_fac * 2e-2)
+                         atol=atol_fac * 5e-3)
         self.assertClose(report.train_adv_train_adv_eval,
                          report_2.train_adv_train_adv_eval,
-                         atol=atol_fac * 2e-1)
+                         atol=atol_fac * 2e-2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Given the atol_fac, the tests had become too loose. the new values allow 1.5% change in the train/test clean/adv accuracies except for adversarial training accuracy that is allowed to change 6%.