### PR TITLE
Alternative implementation for JSMA

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -495,12 +495,14 @@ class SaliencyMapMethod(Attack):
                     return result
 
                 labels, nb_classes = self.get_or_guess_labels(x, kwargs)
-                self.y_target = tf.py_func(random_targets, [labels], tf.float32)
+                self.y_target = tf.py_func(random_targets, [labels],
+                                           tf.float32)
                 self.y_target.set_shape([None, nb_classes])
 
             x_adv = jsma_symbolic(x, model=self.model, y_target=self.y_target,
                                   theta=self.theta, gamma=self.gamma,
-                                  clip_min=self.clip_min, clip_max=self.clip_max)
+                                  clip_min=self.clip_min,
+                                  clip_max=self.clip_max)
         else:
             from .attacks_tf import jacobian_graph, jsma_batch
 
@@ -532,7 +534,7 @@ class SaliencyMapMethod(Attack):
         return x_adv
 
     def parse_params(self, theta=1., gamma=1., nb_classes=None,
-                     clip_min=0., clip_max=1., y_target=None, 
+                     clip_min=0., clip_max=1., y_target=None,
                      symbolic_impl=True, **kwargs):
         """
         Take in a dictionary of parameters and applies attack-specific checks

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -486,7 +486,7 @@ class SaliencyMapMethod(Attack):
         :param y_target: (optional) Target tensor if the attack is targeted
         """
         import tensorflow as tf
-        from .attacks_tf import jsma
+        from .attacks_tf import jsma_symbolic
 
         # Parse and save attack-specific parameters
         assert self.parse_params(**kwargs)
@@ -510,9 +510,9 @@ class SaliencyMapMethod(Attack):
             self.y_target = tf.py_func(random_targets, [labels], tf.float32)
             self.y_target.set_shape([None, nb_classes])
 
-        return jsma(x, model=self.model, y_target=self.y_target,
-                    theta=self.theta, gamma=self.gamma,
-                    clip_min=self.clip_min, clip_max=self.clip_max)
+        return jsma_symbolic(x, model=self.model, y_target=self.y_target,
+                             theta=self.theta, gamma=self.gamma,
+                             clip_min=self.clip_min, clip_max=self.clip_max)
 
     def parse_params(self, theta=1., gamma=1., nb_classes=None,
                      clip_min=0., clip_max=1., y_target=None, **kwargs):

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -514,7 +514,7 @@ class SaliencyMapMethod(Attack):
                     theta=self.theta, gamma=self.gamma,
                     clip_min=self.clip_min, clip_max=self.clip_max)
 
-    def parse_params(self, theta=1., gamma=np.inf, nb_classes=None,
+    def parse_params(self, theta=1., gamma=1., nb_classes=None,
                      clip_min=0., clip_max=1., y_target=None, **kwargs):
         """
         Take in a dictionary of parameters and applies attack-specific checks

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -133,79 +133,6 @@ def vatm(model, x, logits, eps, num_iterations=1, xi=1e-6,
         return adv_x
 
 
-def apply_perturbations(i, j, X, increase, theta, clip_min, clip_max):
-    """
-    TensorFlow implementation for apply perturbations to input features based
-    on salency maps
-    :param i: index of first selected feature
-    :param j: index of second selected feature
-    :param X: a matrix containing our input features for our sample
-    :param increase: boolean; true if we are increasing pixels, false otherwise
-    :param theta: delta for each feature adjustment
-    :param clip_min: mininum value for a feature in our sample
-    :param clip_max: maximum value for a feature in our sample
-    : return: a perturbed input feature matrix for a target class
-    """
-
-    # perturb our input sample
-    if increase:
-        X[0, i] = np.minimum(clip_max, X[0, i] + theta)
-        X[0, j] = np.minimum(clip_max, X[0, j] + theta)
-    else:
-        X[0, i] = np.maximum(clip_min, X[0, i] - theta)
-        X[0, j] = np.maximum(clip_min, X[0, j] - theta)
-
-    return X
-
-
-def saliency_map(grads_target, grads_other, search_domain, increase):
-    """
-    TensorFlow implementation for computing saliency maps
-    :param grads_target: a matrix containing forward derivatives for the
-                         target class
-    :param grads_other: a matrix where every element is the sum of forward
-                        derivatives over all non-target classes at that index
-    :param search_domain: the set of input indices that we are considering
-    :param increase: boolean; true if we are increasing pixels, false otherwise
-    :return: (i, j, search_domain) the two input indices selected and the
-             updated search domain
-    """
-    # Compute the size of the input (the number of features)
-    nf = len(grads_target)
-
-    # Remove the already-used input features from the search space
-    invalid = list(set(range(nf)) - search_domain)
-    increase_coef = (2 * int(increase) - 1)
-    grads_target[invalid] = - increase_coef * np.max(np.abs(grads_target))
-    grads_other[invalid] = increase_coef * np.max(np.abs(grads_other))
-
-    # Create a 2D numpy array of the sum of grads_target and grads_other
-    target_sum = grads_target.reshape((1, nf)) + grads_target.reshape((nf, 1))
-    other_sum = grads_other.reshape((1, nf)) + grads_other.reshape((nf, 1))
-
-    # Create a mask to only keep features that match saliency map conditions
-    if increase:
-        scores_mask = ((target_sum > 0) & (other_sum < 0))
-    else:
-        scores_mask = ((target_sum < 0) & (other_sum > 0))
-
-    # Create a 2D numpy array of the scores for each pair of candidate features
-    scores = scores_mask * (-target_sum * other_sum)
-
-    # A pixel can only be selected (and changed) once
-    np.fill_diagonal(scores, 0)
-
-    # Extract the best two pixels
-    best = np.argmax(scores)
-    p1, p2 = best % nf, best // nf
-
-    # Remove used pixels from our search domain
-    search_domain.discard(p1)
-    search_domain.discard(p2)
-
-    return p1, p2, search_domain
-
-
 def jacobian(sess, x, grads, target, X, nb_features, nb_classes, feed=None):
     """
     TensorFlow implementation of the foward derivative / Jacobian
@@ -257,151 +184,138 @@ def jacobian_graph(predictions, x, nb_classes):
     return list_derivatives
 
 
-def jsma(sess, x, predictions, grads, sample, target, theta, gamma, clip_min,
-         clip_max, feed=None):
+def jsma(x, y_target, model, theta, gamma, clip_min, clip_max):
     """
     TensorFlow implementation of the JSMA (see https://arxiv.org/abs/1511.07528
     for details about the algorithm design choices).
-    :param sess: TF session
+
     :param x: the input placeholder
-    :param predictions: the model's symbolic output (the attack expects the
-                  probabilities, i.e., the output of the softmax, but will
-                  also work with logits typically)
-    :param grads: symbolic gradients
-    :param sample: numpy array with sample input
-    :param target: target class for sample input
+    :param y_target: the target tensor
+    :param model: a cleverhans.model.Model object.
     :param theta: delta for each feature adjustment
     :param gamma: a float between 0 - 1 indicating the maximum distortion
         percentage
     :param clip_min: minimum value for components of the example returned
     :param clip_max: maximum value for components of the example returned
-    :return: an adversarial sample
+    :return: a tensor for the adversarial example
     """
 
-    # Copy the source sample and define the maximum number of features
-    # (i.e. the maximum number of iterations) that we may perturb
-    adv_x = copy.copy(sample)
-    # count the number of features. For MNIST, 1x28x28 = 784; for
-    # CIFAR, 3x32x32 = 3072; etc.
-    nb_features = np.product(adv_x.shape[1:])
-    # reshape sample for sake of standardization
-    original_shape = adv_x.shape
-    adv_x = np.reshape(adv_x, (1, nb_features))
-    # compute maximum number of iterations
+    nb_classes = int(y_target.shape[-1].value)
+    nb_features = int(np.product(x.shape[1:]).value)
+
     max_iters = np.floor(nb_features * gamma / 2)
-
-    # Find number of classes based on grads
-    nb_classes = len(grads)
-
     increase = bool(theta > 0)
+
+    tmp = np.ones((nb_features, nb_features), int)
+    np.fill_diagonal(tmp, 0)
+    zero_diagonal = tf.constant(tmp, tf.float32)
 
     # Compute our initial search domain. We optimize the initial search domain
     # by removing all features that are already at their maximum values (if
     # increasing input features---otherwise, at their minimum value).
     if increase:
-        search_domain = set([i for i in xrange(nb_features)
-                             if adv_x[0, i] < clip_max])
+        search_domain = tf.reshape(
+                            tf.cast(x < clip_max, tf.float32),
+                            [-1, nb_features])
     else:
-        search_domain = set([i for i in xrange(nb_features)
-                             if adv_x[0, i] > clip_min])
+        search_domain = tf.reshape(
+                            tf.cast(x > clip_min, tf.float32),
+                            [-1, nb_features])
 
-    # Initialize the loop variables
-    iteration = 0
-    adv_x_original_shape = np.reshape(adv_x, original_shape)
-    current = utils_tf.model_argmax(sess, x, predictions, adv_x_original_shape,
-                                    feed=feed)
+    def condition(x_in, y_in, domain_in, i_in, cond_in):
+        # Repeat the loop until we have achieved misclassification or
+        # reaches the maximum iterations
+        return tf.logical_and(tf.less(i_in, max_iters), cond_in)
 
-    _logger.debug("Starting JSMA attack up to {} iterations".format(max_iters))
-    # Repeat this main loop until we have achieved misclassification
-    while (current != target and iteration < max_iters and
-           len(search_domain) > 1):
-        # Reshape the adversarial example
-        adv_x_original_shape = np.reshape(adv_x, original_shape)
+    def body(x_in, y_in, domain_in, i_in, cond_in):
+
+        preds = model.get_probs(x_in)
+        preds_onehot = tf.one_hot(tf.argmax(preds, axis=1), depth=nb_classes)
+
+        # create the Jacobian graph
+        list_derivatives = []
+        for class_ind in xrange(nb_classes):
+            derivatives = tf.gradients(preds[:, class_ind], x_in)
+            list_derivatives.append(derivatives[0])
+        grads = tf.reshape(tf.stack(list_derivatives),
+                           shape=[nb_classes, -1, nb_features])
 
         # Compute the Jacobian components
-        grads_target, grads_others = jacobian(sess, x, grads, target,
-                                              adv_x_original_shape,
-                                              nb_features, nb_classes,
-                                              feed=feed)
+        target_class = tf.reshape(tf.transpose(y_in, perm=[1, 0]),
+                                  shape=[nb_classes, -1, 1])
+        other_classes = tf.cast(tf.not_equal(target_class, 1), tf.float32)
 
-        if iteration % ((max_iters + 1) // 5) == 0 and iteration > 0:
-            _logger.debug("Iteration {} of {}".format(iteration,
-                                                      int(max_iters)))
-        # Compute the saliency map for each of our target classes
-        # and return the two best candidate features for perturbation
-        i, j, search_domain = saliency_map(
-            grads_target, grads_others, search_domain, increase)
+        grads_target = tf.reduce_sum(grads * target_class, axis=0)
+        grads_other = tf.reduce_sum(grads * other_classes, axis=0)
 
-        # Apply the perturbation to the two input features selected previously
-        adv_x = apply_perturbations(
-            i, j, adv_x, increase, theta, clip_min, clip_max)
+        # Remove the already-used input features from the search space
+        # Subtract 2 times the maximum value from those value so that
+        # they won't be picked later
+        increase_coef = (4 * int(increase) - 2) \
+            * tf.cast(tf.equal(domain_in, 0), tf.float32)
 
-        # Update our current prediction by querying the model
-        current = utils_tf.model_argmax(sess, x, predictions,
-                                        adv_x_original_shape, feed=feed)
+        target_tmp = grads_target
+        target_tmp -= increase_coef \
+            * tf.reduce_max(tf.abs(grads_target), axis=1, keep_dims=True)
+        target_sum = tf.reshape(target_tmp, shape=[-1, nb_features, 1]) \
+            + tf.reshape(target_tmp, shape=[-1, 1, nb_features])
 
-        # Update loop variables
-        iteration = iteration + 1
+        other_tmp = grads_other
+        other_tmp += increase_coef \
+            * tf.reduce_max(tf.abs(grads_other), axis=1, keep_dims=True)
+        other_sum = tf.reshape(other_tmp, shape=[-1, nb_features, 1]) \
+            + tf.reshape(other_tmp, shape=[-1, 1, nb_features])
 
-    if current == target:
-        _logger.info("Attack succeeded using {} iterations".format(iteration))
-    else:
-        _logger.info(("Failed to find adversarial example " +
-                      "after {} iterations").format(iteration))
-
-    # Compute the ratio of pixels perturbed by the algorithm
-    percent_perturbed = float(iteration * 2) / nb_features
-
-    # Report success when the adversarial example is misclassified in the
-    # target class
-    if current == target:
-        return np.reshape(adv_x, original_shape), 1, percent_perturbed
-    else:
-        return np.reshape(adv_x, original_shape), 0, percent_perturbed
-
-
-def jsma_batch(sess, x, pred, grads, X, theta, gamma, clip_min, clip_max,
-               nb_classes, y_target=None, feed=None, **kwargs):
-    """
-    Applies the JSMA to a batch of inputs
-    :param sess: TF session
-    :param x: the input placeholder
-    :param pred: the model's symbolic output
-    :param grads: symbolic gradients
-    :param X: numpy array with sample inputs
-    :param theta: delta for each feature adjustment
-    :param gamma: a float between 0 - 1 indicating the maximum distortion
-        percentage
-    :param clip_min: minimum value for components of the example returned
-    :param clip_max: maximum value for components of the example returned
-    :param nb_classes: number of model output classes
-    :param y_target: target class for sample input
-    :return: adversarial examples
-    """
-    if 'targets' in kwargs:
-        warnings.warn('The targets parameter is deprecated, use y_target.'
-                      'targets will be removed on 2018-02-03.')
-        y_target = kwargs['targets']
-
-    X_adv = np.zeros(X.shape)
-
-    for ind, val in enumerate(X):
-        val = np.expand_dims(val, axis=0)
-        if y_target is None:
-            # No y_target provided, randomly choose from other classes
-            from .utils_tf import model_argmax
-            gt = model_argmax(sess, x, pred, val, feed=feed)
-
-            # Randomly choose from the incorrect classes for each sample
-            from .utils import random_targets
-            target = random_targets(gt, nb_classes)[0]
+        # Create a mask to only keep features that match conditions
+        if increase:
+            scores_mask = ((target_sum > 0) & (other_sum < 0))
         else:
-            target = y_target[ind]
+            scores_mask = ((target_sum < 0) & (other_sum > 0))
 
-        X_adv[ind], _, _ = jsma(sess, x, pred, grads, val, np.argmax(target),
-                                theta, gamma, clip_min, clip_max, feed=feed)
+        # Create a 2D numpy array of scores for each pair of candidate features
+        scores = tf.cast(scores_mask, tf.float32) \
+            * (-target_sum * other_sum) * zero_diagonal
 
-    return np.asarray(X_adv, dtype=np.float32)
+        # Extract the best two pixels
+        best = tf.argmax(
+                    tf.reshape(scores, shape=[-1, nb_features * nb_features]),
+                    axis=1)
+
+        p1 = tf.mod(best, nb_features)
+        p2 = tf.floordiv(best, nb_features)
+        p1_one_hot = tf.one_hot(p1, depth=nb_features)
+        p2_one_hot = tf.one_hot(p2, depth=nb_features)
+
+        # Check if more modification is needed for each samples
+        mod_done = tf.equal(tf.reduce_sum(y_in * preds_onehot, axis=1), 0)
+        cond = mod_done & (tf.reduce_sum(domain_in, axis=1) >= 2)
+
+        # Update the search domain
+        cond_float = tf.reshape(tf.cast(cond, tf.float32), shape=[-1, 1])
+        to_mod = (p1_one_hot + p2_one_hot) * cond_float
+
+        domain_out = domain_in - to_mod
+
+        # Apply the modification to the images
+        to_mod_reshape = tf.reshape(to_mod,
+                                    shape=([-1] + x_in.shape[1:].as_list()))
+        if increase:
+            x_out = tf.minimum(clip_max, x_in + to_mod_reshape * theta)
+        else:
+            x_out = tf.maximum(clip_min, x_in - to_mod_reshape * theta)
+
+        # Increase the iterator, and check if all misclassifications are done
+        i_out = tf.add(i_in, 1)
+        cond_out = tf.reduce_any(cond)
+
+        return x_out, y_in, domain_out, i_out, cond_out
+
+    # Run loop to do JSMA
+    x_adv, _, _, _, _ = tf.while_loop(condition, body,
+                                      [x, y_target, search_domain, 0, True],
+                                      parallel_iterations=1)
+
+    return x_adv
 
 
 def jacobian_augmentation(sess, x, X_sub_prev, Y_sub, grads, lmbda,

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -623,10 +623,10 @@ class TestSaliencyMapMethod(CleverHansTest):
         x_val = np.random.rand(10, 1000)
         x_val = np.array(x_val, dtype=np.float32)
 
-        feed_labs = np.zeros((10, 1000))
+        feed_labs = np.zeros((10, 10))
         feed_labs[np.arange(10), np.random.randint(0, 9, 10)] = 1
         x_adv = self.attack.generate_np(x_val,
-                                        clip_min=-5, clip_max=5,
+                                        clip_min=-5., clip_max=5.,
                                         y_target=feed_labs)
         new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
 

--- a/tests_tf/test_mnist_tutorial_tf.py
+++ b/tests_tf/test_mnist_tutorial_tf.py
@@ -39,7 +39,7 @@ class TestMNISTTutorialTF(CleverHansTest):
                          atol=atol_fac * 5e-3)
         self.assertClose(report.train_adv_train_clean_eval,
                          report_2.train_adv_train_clean_eval,
-                         atol=atol_fac * 5e-3)
+                         atol=atol_fac * 2e-2)
         self.assertClose(report.train_adv_train_adv_eval,
                          report_2.train_adv_train_adv_eval,
                          atol=atol_fac * 2e-2)


### PR DESCRIPTION
I know there is currently another open pull request for the JSMA, but I just want to share the work I have done and hopefully it can help too.

My motivation for the change is to improve the efficiency to generate adversarial examples for JSMA. With the change, the time needed for generation should be greatly reduced. I haven't done a precise measurement, but it roughly takes about 15 sec to generate 500 adversarial samples with GPU.

The change tries to keeps the same interface of the original implementation, so that no modification is needed for tutorial.

I have run the tests in the test_tf and the tutorial. I think there is something wrong with the "test_generate_np_targeted_gives_adversarial_example" test. I tried to fix it, but I can't find a good way to do so. Maybe someone can comment on what the test is trying to do.

Any comments and suggestions are appreciated.