### PR TITLE
Compatibility update for Keras 2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service libgcc
   - source activate test-environment
   # install TensorFlow
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.4.1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service libgcc
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service
   - source activate test-environment
   # install TensorFlow
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.4.1" ]]; then

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -14,6 +14,7 @@ if LooseVersion(keras.__version__) >= LooseVersion('2.0.0'):
 else:
     from keras.layers import Convolution2D
 
+import warnings
 
 def conv_2d(filters, kernel_shape, strides, padding, input_shape=None):
     """
@@ -138,7 +139,16 @@ class KerasModelWrapper(Model):
         """
         softmax_name = self._get_softmax_name()
         softmax_layer = self.model.get_layer(softmax_name)
-        node = softmax_layer.inbound_nodes[0]
+
+        if hasattr(softmax_layer, 'inbound_nodes'):
+          warnings.warn(
+              "Please update your version to keras >= 2.1.3; "
+              "future verions of CleverHans may drop support for this version"
+          )
+          node = softmax_layer.inbound_nodes[0]
+        else:
+          node = softmax_layer._inbound_nodes[0]
+
         logits_name = node.inbound_layers[0].name
 
         return logits_name

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -1,20 +1,19 @@
 """
 Model construction utilities based on keras
 """
-from .model import Model
-
+import warnings
+from distutils.version import LooseVersion
 import keras
 from keras.utils import np_utils
 from keras.models import Sequential
 from keras.layers import Dense, Activation, Flatten
+from .model import Model
 
-from distutils.version import LooseVersion
 if LooseVersion(keras.__version__) >= LooseVersion('2.0.0'):
     from keras.layers import Conv2D
 else:
     from keras.layers import Convolution2D
 
-import warnings
 
 def conv_2d(filters, kernel_shape, strides, padding, input_shape=None):
     """
@@ -141,13 +140,13 @@ class KerasModelWrapper(Model):
         softmax_layer = self.model.get_layer(softmax_name)
 
         if hasattr(softmax_layer, 'inbound_nodes'):
-          warnings.warn(
-              "Please update your version to keras >= 2.1.3; "
-              "future verions of CleverHans may drop support for this version"
-          )
-          node = softmax_layer.inbound_nodes[0]
+            warnings.warn(
+                "Please update your version to keras >= 2.1.3; "
+                "support for earlier keras versions will be dropped on "
+                "2018-07-22")
+            node = softmax_layer.inbound_nodes[0]
         else:
-          node = softmax_layer._inbound_nodes[0]
+            node = softmax_layer._inbound_nodes[0]
 
         logits_name = node.inbound_layers[0].name
 


### PR DESCRIPTION
In Keras 2.1.3, inbound_nodes has been renamed to _inbound_nodes. Use a hasattr check to choose which property to use, and warn the user that support for the <2.1.3 behavior may be dropped.

see https://github.com/keras-team/keras/commit/958239c621a6be037c5f8b30be9270310735f725#diff-fe3ca734e8421a17729d0b0ea4c800ba