### PR TITLE
Fix keras incompatibility, libgcc issue, and typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service
   - source activate test-environment
+
   # install TensorFlow
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.4.1" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp27-none-linux_x86_64.whl;
@@ -51,6 +52,12 @@ install:
     fi
   - pip install keras
   - python setup.py install
+
+  # workaround for version incompatibility between the scipy version in conda
+  # and the system-provided /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+  # by installing a conda-provided libgcc and adding it to the load path
+  - conda install libgcc
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/miniconda/envs/test-environment/lib
 
 # command to run tests
 script:

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -1,14 +1,14 @@
 """
 Model construction utilities based on keras
 """
-from .model import Model
-
+import warnings
+from distutils.version import LooseVersion
 import keras
 from keras.utils import np_utils
 from keras.models import Sequential
 from keras.layers import Dense, Activation, Flatten
+from .model import Model
 
-from distutils.version import LooseVersion
 if LooseVersion(keras.__version__) >= LooseVersion('2.0.0'):
     from keras.layers import Conv2D
 else:
@@ -138,7 +138,16 @@ class KerasModelWrapper(Model):
         """
         softmax_name = self._get_softmax_name()
         softmax_layer = self.model.get_layer(softmax_name)
-        node = softmax_layer.inbound_nodes[0]
+
+        if hasattr(softmax_layer, 'inbound_nodes'):
+            warnings.warn(
+                "Please update your version to keras >= 2.1.3; "
+                "support for earlier keras versions will be dropped on "
+                "2018-07-22")
+            node = softmax_layer.inbound_nodes[0]
+        else:
+            node = softmax_layer._inbound_nodes[0]
+
         logits_name = node.inbound_layers[0].name
 
         return logits_name

--- a/examples/multigpu_advtrain/trainer.py
+++ b/examples/multigpu_advtrain/trainer.py
@@ -1,6 +1,6 @@
 """
 This module provides Trainer classes that given a set of flags, create,
-initialize and train a model. Theese classes use Runner objects to handle
+initialize and train a model. These classes use Runner objects to handle
 multigpu/singlegpu training.
 """
 import six


### PR DESCRIPTION
Fix for issue #339 - use conda-provided libgcc
Fix for issue #340 - change API for new keras and add deprecation notice for old keras
Fix typo