### PR TITLE
Fix detection of Softmax op in utils_tf.model_loss() 

### DIFF
--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -31,7 +31,7 @@ def model_loss(y, model, mean=True):
     """
 
     op = model.op
-    if "softmax" in str(op).lower():
+    if op.type == "Softmax":
         logits, = op.inputs
     else:
         logits = model


### PR DESCRIPTION
**What:** ValueError when applying fgm() to Keras models whose output is a concatenation of softmax-named inputs, but not a softmax op itself.

**Why:** Currently, a Softmax output op is found by comparison of str(op). This can result in false detections, for example if the op is concatenating several Softmax inputs.

**Example:** Here is a Keras network with such an output op: https://github.com/pierluigiferrari/ssd_keras/blob/master/keras_ssd300.py#L390

	>>> str(op)
	'name: "model_1/predictions/concat"\nop: "ConcatV2"\ninput: "model_1/mbox_conf_softmax/truediv"\ninput: "model_1/mbox_loc/concat"\ninput: "model_1/mbox_priorbox/concat"\ninput: "model_1/predictions/concat/axis"\nattr {\n  key: "N"\n  value {\n    i: 3\n  }\n}\nattr {\n  key: "T"\n  value {\n    type: DT_FLOAT\n  }\n}\nattr {\n  key: "Tidx"\n  value {\n    type: DT_INT32\n  }\n}\n'
	>>> op.type
	'ConcatV2'
		
This will result in "ValueError: too many values to unpack (expected 1)" (utils_tf.py:35).

**Proposed fix**: Use op.type instead of str(op) for comparison. 

This allows the user to successfully use fgm with the SSD above - although they might want to use their own loss function to make the attack work better.

Thanks!