### PR TITLE
Add module-level docstring for tutorials

### DIFF
--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -1,3 +1,9 @@
+"""
+This tutorial shows how to generate adversarial examples
+using FGSM in black-box setting.
+The original paper can be found at:
+https://arxiv.org/abs/1602.02697
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -1,3 +1,9 @@
+"""
+This tutorial shows how to generate adversarial examples
+using C&W attack in white-box setting.
+The original paper can be found at:
+https://nicholas.carlini.com/papers/2017_sp_nnrobustattacks.pdf
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -1,3 +1,9 @@
+"""
+This tutorial shows how to generate adversarial examples
+using JSMA in white-box setting.
+The original paper can be found at:
+https://arxiv.org/abs/1511.07528
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -1,3 +1,11 @@
+"""
+This tutorial shows how to generate adversarial examples using FGSM
+and train a model using adversarial training with Keras.
+It is very similar to mnist_tutorial_tf.py, which does the same
+thing but without a dependence on keras.
+The original paper can be found at:
+https://arxiv.org/abs/1412.6572
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -1,9 +1,10 @@
 """
-This tutorial shows how to generate some simple adversarial examples
-and train a model using adversarial training using nothing but pure
-TensorFlow.
+This tutorial shows how to generate adversarial examples using FGSM
+and train a model using adversarial training with TensorFlow.
 It is very similar to mnist_tutorial_keras_tf.py, which does the same
 thing but with a dependence on keras.
+The original paper can be found at:
+https://arxiv.org/abs/1412.6572
 """
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
In order to 

1. Enable the docstring linter (#336) and ensure it's happy (it checks whether files contain module-level docstring
2. Make docstring of tutorials more consistent (now only two tutorials have module-level docstring)

I think it would be helpful to add module-level docstring to all tutorials.