### PR TITLE
Fixing bug in get_logits method of KerasModelWrapper

### DIFF
--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -167,11 +167,10 @@ class KerasModelWrapper(Model):
         # Need to deal with the case where softmax is part of the
         # logits layer
         if logits_name == self._get_softmax_name():
-            softmax_logit_layer = self.model.get_layer(logits_name)
-            softmax_out = softmax_logit_layer.output
+            softmax_logit_layer = self.get_layer(x, logits_name)
 
             # The final op is the softmax. Return its input
-            logits_layer = softmax_out._op.inputs[0]
+            logits_layer = softmax_logit_layer._op.inputs[0]
 
         return logits_layer
 


### PR DESCRIPTION
Fix #307 

Keras supports two methods for adding activations to layers. The first is to add an `Activation` layer to the definition of a model:

    model_1 = Sequential()
    model_1.add(Dense(10, input_shape=(10,), name='not_logits'))
    model_1.add(Dense(10, name='logits'))
    model_1.add(Activation('softmax', name='softmax'))

The second method is to include an activation in the layer directly using the `activation` keyword arg:

    model_2 = Sequential()
    model_2.add(Dense(10, input_shape=(10,), name='not_logits'))
    model_2.add(Dense(10, name='logits_and_softmax', activation='softmax'))

The `get_logits` method of the `KerasModelWrapper` finds the logits layer by first finding the sotfmax layer and then returning the node that is the input to the softmax layer. This works with method 1 but breaks with method 2.

    >>> wrapped_1 = KerasModelWrapper(model_1)
    >>> wrapped_2 = KerasModelWrapper(model_2)
    >>> print("Model 1 Logit Layer: {}\n".format(wrapped_1.get_logits(model_1.input).name))
    Model 1 Logit Layer: model_1/logits/BiasAdd:0

    >>> print("Model 2 Logit Layer: {}\n".format(wrapped_2.get_logits(model_2.input).name))
    Model 2 Logit Layer: model_2/not_logits/BiasAdd:0

**Fix:** If the softmax layer is not an instance of `Activation`, return the input to the softmax `_op` of the softmax layer instead of the output of the previous layer.