### PR TITLE
Fix issues with cleverhans dev version.

### DIFF
--- a/cleverhans/__init__.py
+++ b/cleverhans/__init__.py
@@ -1,5 +1,5 @@
 from cleverhans.devtools.version import append_dev_version
 
-# If possible attach a hex digest to the version string to keep track of changes
-# in the development branch
+# If possible attach a hex digest to the version string to keep track of
+# changes in the development branch
 __version__ = append_dev_version('2.0.0')

--- a/cleverhans/__init__.py
+++ b/cleverhans/__init__.py
@@ -1,5 +1,5 @@
-from cleverhans.devtools.version import dev_version
+from cleverhans.devtools.version import append_dev_version
 
-# Attach a hex digest to the version string to keep track of changes
+# If possible attach a hex digest to the version string to keep track of changes
 # in the development branch
-__version__ = '2.0.0-' + dev_version()
+__version__ = append_dev_version('2.0.0')

--- a/cleverhans/devtools/list_files.py
+++ b/cleverhans/devtools/list_files.py
@@ -1,15 +1,6 @@
 """Code for listing files that belong to the library."""
-import logging
-import cleverhans
 import os
-__authors__ = "Ian Goodfellow"
-__copyright__ = "Copyright 2010-2012, Universite de Montreal"
-__credits__ = ["Ian Goodfellow"]
-__license__ = "3-clause BSD"
-__maintainer__ = "LISA Lab"
-__email__ = "pylearn-dev@googlegroups"
-
-logger = logging.getLogger(__name__)
+import cleverhans
 
 
 def list_files(suffix=""):
@@ -28,8 +19,11 @@ def list_files(suffix=""):
     """
 
     cleverhans_path = os.path.abspath(cleverhans.__path__[0])
+    # In some environments cleverhans_path does not point to a real directory.
+    # In such case return empty list.
+    if not os.path.isdir(cleverhans_path):
+        return []
     repo_path = os.path.abspath(os.path.join(cleverhans_path, os.pardir))
-
     file_list = _list_files(cleverhans_path, suffix)
 
     tutorials_path = os.path.join(repo_path, "cleverhans_tutorials")
@@ -74,8 +68,8 @@ def _list_files(path, suffix=""):
         complete = [os.path.join(path, entry) for entry in incomplete]
         lists = [_list_files(subpath, suffix) for subpath in complete]
         flattened = []
-        for l in lists:
-            for elem in l:
+        for one_list in lists:
+            for elem in one_list:
                 flattened.append(elem)
         return flattened
     else:
@@ -83,10 +77,3 @@ def _list_files(path, suffix=""):
         if path.endswith(suffix):
             return [path]
         return []
-
-
-if __name__ == '__main__':
-    # Print all .py files in the library
-    result = list_files('.py')
-    for path in result:
-        logger.info(path)

--- a/cleverhans/devtools/version.py
+++ b/cleverhans/devtools/version.py
@@ -13,10 +13,23 @@ def dev_version():
     Returns a hexdigest of all the python files in the module.
     """
 
-    m = hashlib.md5()
+    md5_hash = hashlib.md5()
     py_files = sorted(list_files(suffix=".py"))
+    if not py_files:
+        return ''
     for filename in py_files:
-        with open(filename, 'rb') as f:
-            content = f.read()
-        m.update(content)
-    return m.hexdigest()
+        with open(filename, 'rb') as fobj:
+            content = fobj.read()
+        md5_hash.update(content)
+    return md5_hash.hexdigest()
+
+def append_dev_version(release_version):
+    """
+    If dev version is not empty appends it to release_version.
+    """
+
+    dev_version_value = dev_version()
+    if dev_version_value:
+        return release_version + '-' + dev_version_value
+    else:
+        return release_version

--- a/cleverhans/devtools/version.py
+++ b/cleverhans/devtools/version.py
@@ -23,6 +23,7 @@ def dev_version():
         md5_hash.update(content)
     return md5_hash.hexdigest()
 
+
 def append_dev_version(release_version):
     """
     If dev version is not empty appends it to release_version.


### PR DESCRIPTION
In some environments cleverhans.__path__ does not point to real
directory. This will cause "import cleverhans" to fail
because __init__.py tried to compute fine grained cleverhans version
by reading files from cleverhans.__path__

This commit fixes this isssue.

Also it fixes few formatting error to make pylint happy.