### PR TITLE
Update ex_cifar10_tf from fgsm to FastGradientMethod

### DIFF
--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -12,7 +12,7 @@ import tensorflow as tf
 from tensorflow.python.platform import app
 from tensorflow.python.platform import flags
 
-from cleverhans.attacks import fgsm
+from cleverhans.attacks import FastGradientMethod
 from cleverhans.utils_keras import cnn_model
 from cleverhans.utils_tf import model_train, model_eval, batch_eval
 
@@ -117,7 +117,8 @@ def main(argv=None):
                 evaluate=evaluate, args=train_params)
 
     # Craft adversarial examples using Fast Gradient Sign Method (FGSM)
-    adv_x = fgsm(x, predictions, eps=0.3)
+    fgsm = FastGradientMethod(model)
+    adv_x = fgsm.generate(x, eps=0.3)
     eval_params = {'batch_size': FLAGS.batch_size}
     X_test_adv, = batch_eval(sess, [x], [adv_x], [X_test], args=eval_params)
     assert X_test_adv.shape[0] == 10000, X_test_adv.shape
@@ -131,7 +132,7 @@ def main(argv=None):
     # Redefine TF model graph
     model_2 = cnn_model(img_rows=32, img_cols=32, channels=3)
     predictions_2 = model_2(x)
-    adv_x_2 = fgsm(x, predictions_2, eps=0.3)
+    adv_x_2 = fgsm.generate(x, eps=0.3)
     predictions_2_adv = model_2(adv_x_2)
 
     def evaluate_2():

--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -132,7 +132,8 @@ def main(argv=None):
     # Redefine TF model graph
     model_2 = cnn_model(img_rows=32, img_cols=32, channels=3)
     predictions_2 = model_2(x)
-    adv_x_2 = fgsm.generate(x, eps=0.3)
+    fgsm_2 = FastGradientMethod(model_2)
+    adv_x_2 = fgsm_2.generate(x, eps=0.3)
     predictions_2_adv = model_2(adv_x_2)
 
     def evaluate_2():


### PR DESCRIPTION
Bug: Currently the `ex_cifar10_tf.py` example is broken due to a change in the fgsm API.

To reproduce: install the current version of cleverhans with `python setup.py install` and run the example.

Expected:
```
$ python ex_cifar10_tf.py
 Test accuracy on legitimate test examples: 0.4957
 Test accuracy on legitimate test examples: 0.5728
...
```

Actual:
```
$ python ex_cifar10_tf.py
Using TensorFlow backend.
Traceback (most recent call last):
  File "ex_cifar10_tf.py", line 15, in <module>
    from cleverhans.attacks import fgsm
ImportError: cannot import name 'fgsm'
```

This PR updates `ex_cifar10_tf.py` to use the new FastGradientMethod class.