### PR TITLE
modifications to allow dtype to be passed as input to Attack classes

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -17,7 +17,7 @@ class Attack(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         :param model: An instance of the cleverhans.model.Model class.
         :param back: The backend to use. Currently 'tf' is the only option.
@@ -26,10 +26,18 @@ class Attack(object):
         if not(back == 'tf'):
             raise ValueError("Backend argument must either be 'tf'.")
 
-        if back == 'tf' and sess is None:
+        if back == 'tf':
             import tensorflow as tf
-            sess = tf.get_default_session()
-
+            self.tf_dtype=tf.as_dtype(dtypestr)
+            if sess is None:
+                sess = tf.get_default_session()
+        
+        self.np_dtype=np.dtype(dtypestr)
+        
+        import cleverhans.attacks_tf as attacks_tf
+        attacks_tf.np_dtype=self.np_dtype
+        attacks_tf.tf_dtype=self.tf_dtype
+        
         if not isinstance(model, Model):
             raise ValueError("The model argument should be an instance of"
                              " the cleverhans.model.Model class.")
@@ -109,7 +117,7 @@ class Attack(object):
 
         # x is a special placeholder we always want to have
         x_shape = [None] + list(x_val.shape)[1:]
-        x = tf.placeholder(tf.float32, shape=x_shape)
+        x = tf.placeholder(self.tf_dtype, shape=x_shape)
 
         # now we generate the graph that we want
         x_adv = self.generate(x, **new_kwargs)
@@ -236,7 +244,7 @@ class FastGradientMethod(Attack):
     Paper link: https://arxiv.org/abs/1412.6572
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a FastGradientMethod instance.
         Note: the model parameter should be an instance of the
@@ -245,12 +253,12 @@ class FastGradientMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(FastGradientMethod, self).__init__(model, back, sess)
-        self.feedable_kwargs = {'eps': np.float32,
-                                'y': np.float32,
-                                'y_target': np.float32,
-                                'clip_min': np.float32,
-                                'clip_max': np.float32}
+        super(FastGradientMethod, self).__init__(model, back, sess, dtypestr)
+        self.feedable_kwargs = {'eps': self.np_dtype,
+                                'y': self.np_dtype,
+                                'y_target': self.np_dtype,
+                                'clip_min': self.np_dtype,
+                                'clip_max': self.np_dtype}
         self.structural_kwargs = ['ord']
 
     def generate(self, x, **kwargs):
@@ -333,7 +341,7 @@ class BasicIterativeMethod(Attack):
     Paper link: https://arxiv.org/pdf/1607.02533.pdf
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a BasicIterativeMethod instance.
         Note: the model parameter should be an instance of the
@@ -342,13 +350,13 @@ class BasicIterativeMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(BasicIterativeMethod, self).__init__(model, back, sess)
-        self.feedable_kwargs = {'eps': np.float32,
-                                'eps_iter': np.float32,
-                                'y': np.float32,
-                                'y_target': np.float32,
-                                'clip_min': np.float32,
-                                'clip_max': np.float32}
+        super(BasicIterativeMethod, self).__init__(model, back, sess, dtypestr)
+        self.feedable_kwargs = {'eps': self.np_dtype,
+                                'eps_iter': self.np_dtype,
+                                'y': self.np_dtype,
+                                'y_target': self.np_dtype,
+                                'clip_min': self.np_dtype,
+                                'clip_max': self.np_dtype}
         self.structural_kwargs = ['ord', 'nb_iter']
 
     def generate(self, x, **kwargs):
@@ -469,7 +477,7 @@ class MomentumIterativeMethod(Attack):
     Paper link: https://arxiv.org/pdf/1710.06081.pdf
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a MomentumIterativeMethod instance.
         Note: the model parameter should be an instance of the
@@ -478,13 +486,13 @@ class MomentumIterativeMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(MomentumIterativeMethod, self).__init__(model, back, sess)
-        self.feedable_kwargs = {'eps': np.float32,
-                                'eps_iter': np.float32,
-                                'y': np.float32,
-                                'y_target': np.float32,
-                                'clip_min': np.float32,
-                                'clip_max': np.float32}
+        super(MomentumIterativeMethod, self).__init__(model, back, sess, dtypestr)
+        self.feedable_kwargs = {'eps': self.np_dtype,
+                                'eps_iter': self.np_dtype,
+                                'y': self.np_dtype,
+                                'y_target': self.np_dtype,
+                                'clip_min': self.np_dtype,
+                                'clip_max': self.np_dtype}
         self.structural_kwargs = ['ord', 'nb_iter', 'decay_factor']
 
     def generate(self, x, **kwargs):
@@ -622,7 +630,7 @@ class SaliencyMapMethod(Attack):
     Paper link: https://arxiv.org/pdf/1511.07528.pdf
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a SaliencyMapMethod instance.
         Note: the model parameter should be an instance of the
@@ -631,10 +639,10 @@ class SaliencyMapMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(SaliencyMapMethod, self).__init__(model, back, sess)
+        super(SaliencyMapMethod, self).__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
-        self.feedable_kwargs = {'y_target': tf.float32}
+        self.feedable_kwargs = {'y_target': self.tf_dtype}
         self.structural_kwargs = ['theta', 'gamma',
                                   'clip_max', 'clip_min', 'symbolic_impl']
 
@@ -675,7 +683,7 @@ class SaliencyMapMethod(Attack):
 
                 labels, nb_classes = self.get_or_guess_labels(x, kwargs)
                 self.y_target = tf.py_func(random_targets, [labels],
-                                           tf.float32)
+                                           self.tf_dtype)
                 self.y_target.set_shape([None, nb_classes])
 
             x_adv = jsma_symbolic(x, model=self.model, y_target=self.y_target,
@@ -699,7 +707,7 @@ class SaliencyMapMethod(Attack):
                                       y_target=y_target)
 
                 # Attack is targeted, target placeholder will need to be fed
-                x_adv = tf.py_func(jsma_wrap, [x, self.y_target], tf.float32)
+                x_adv = tf.py_func(jsma_wrap, [x, self.y_target], self.tf_dtype)
             else:
                 def jsma_wrap(x_val):
                     return jsma_batch(self.sess, x, preds, grads, x_val,
@@ -708,7 +716,7 @@ class SaliencyMapMethod(Attack):
                                       y_target=None)
 
                 # Attack is untargeted, target values will be chosen at random
-                x_adv = tf.py_func(jsma_wrap, [x], tf.float32)
+                x_adv = tf.py_func(jsma_wrap, [x], self.tf_dtype)
 
         return x_adv
 
@@ -752,7 +760,7 @@ class VirtualAdversarialMethod(Attack):
 
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Note: the model parameter should be an instance of the
         cleverhans.model.Model abstraction provided by CleverHans.
@@ -760,12 +768,12 @@ class VirtualAdversarialMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
 
-        super(VirtualAdversarialMethod, self).__init__(model, back, sess)
+        super(VirtualAdversarialMethod, self).__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
-        self.feedable_kwargs = {'eps': tf.float32, 'xi': tf.float32,
-                                'clip_min': tf.float32,
-                                'clip_max': tf.float32}
+        self.feedable_kwargs = {'eps': self.tf_dtype, 'xi': self.tf_dtype,
+                                'clip_min': self.tf_dtype,
+                                'clip_max': self.tf_dtype}
         self.structural_kwargs = ['num_iterations']
 
     def generate(self, x, **kwargs):
@@ -821,19 +829,19 @@ class CarliniWagnerL2(Attack):
     lower distortion than other attacks. This comes at the cost of speed,
     as this attack is often much slower than others.
     """
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Note: the model parameter should be an instance of the
         cleverhans.model.Model abstraction provided by CleverHans.
         """
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
-
-        super(CarliniWagnerL2, self).__init__(model, back, sess)
+        
+        super(CarliniWagnerL2, self).__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
-        self.feedable_kwargs = {'y': tf.float32,
-                                'y_target': tf.float32}
+        self.feedable_kwargs = {'y': self.tf_dtype,
+                                'y_target': self.tf_dtype}
 
         self.structural_kwargs = ['batch_size', 'confidence',
                                   'targeted', 'learning_rate',
@@ -885,17 +893,17 @@ class CarliniWagnerL2(Attack):
         self.parse_params(**kwargs)
 
         labels, nb_classes = self.get_or_guess_labels(x, kwargs)
-
+        
         attack = CWL2(self.sess, self.model, self.batch_size,
                       self.confidence, 'y_target' in kwargs,
                       self.learning_rate, self.binary_search_steps,
                       self.max_iterations, self.abort_early,
                       self.initial_const, self.clip_min, self.clip_max,
                       nb_classes, x.get_shape().as_list()[1:])
-
+        
         def cw_wrap(x_val, y_val):
-            return np.array(attack.attack(x_val, y_val), dtype=np.float32)
-        wrap = tf.py_func(cw_wrap, [x, labels], tf.float32)
+            return np.array(attack.attack(x_val, y_val), dtype=self.np_dtype)
+        wrap = tf.py_func(cw_wrap, [x, labels], self.tf_dtype)
 
         return wrap
 
@@ -931,7 +939,7 @@ class ElasticNetMethod(Attack):
     and complement adversarial training.
     Paper link: https://arxiv.org/abs/1709.04114
     """
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Note: the model parameter should be an instance of the
         cleverhans.model.Model abstraction provided by CleverHans.
@@ -939,11 +947,11 @@ class ElasticNetMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
 
-        super(ElasticNetMethod, self).__init__(model, back, sess)
+        super(ElasticNetMethod, self).__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
-        self.feedable_kwargs = {'y': tf.float32,
-                                'y_target': tf.float32}
+        self.feedable_kwargs = {'y': self.tf_dtype,
+                                'y_target': self.tf_dtype}
 
         self.structural_kwargs = ['fista', 'beta', 'decision_rule',
                                   'batch_size', 'confidence',
@@ -1014,8 +1022,8 @@ class ElasticNetMethod(Attack):
                      nb_classes, x.get_shape().as_list()[1:])
 
         def ead_wrap(x_val, y_val):
-            return np.array(attack.attack(x_val, y_val), dtype=np.float32)
-        wrap = tf.py_func(ead_wrap, [x, labels], tf.float32)
+            return np.array(attack.attack(x_val, y_val), dtype=self.np_dtype)
+        wrap = tf.py_func(ead_wrap, [x, labels], self.tf_dtype)
 
         return wrap
 
@@ -1054,14 +1062,14 @@ class DeepFool(Attack):
     Paper link: "https://arxiv.org/pdf/1511.04599.pdf"
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a DeepFool instance.
         """
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
 
-        super(DeepFool, self).__init__(model, back, sess)
+        super(DeepFool, self).__init__(model, back, sess, dtypestr)
 
         self.structural_kwargs = ['over_shoot', 'max_iter', 'clip_max',
                                   'clip_min', 'nb_candidate']
@@ -1105,7 +1113,7 @@ class DeepFool(Attack):
                                   self.nb_candidate, self.overshoot,
                                   self.max_iter, self.clip_min, self.clip_max,
                                   self.nb_classes)
-        return tf.py_func(deepfool_wrap, [x], tf.float32)
+        return tf.py_func(deepfool_wrap, [x], self.tf_dtype)
 
     def parse_params(self, nb_candidate=10, overshoot=0.02, max_iter=50,
                      nb_classes=None, clip_min=0., clip_max=1., **kwargs):
@@ -1139,7 +1147,7 @@ class LBFGS(Attack):
     and is a target & iterative attack.
     Paper link: "https://arxiv.org/pdf/1312.6199.pdf"
     """
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Note: the model parameter should be an instance of the
         cleverhans.model.Model abstraction provided by CleverHans.
@@ -1147,10 +1155,10 @@ class LBFGS(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(LBFGS, self).__init__(model, back, sess)
+        super(LBFGS, self).__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
-        self.feedable_kwargs = {'y_target': tf.float32}
+        self.feedable_kwargs = {'y_target': self.tf_dtype}
         self.structural_kwargs = ['batch_size', 'binary_search_steps',
                                   'max_iterations', 'initial_const',
                                   'clip_min', 'clip_max']
@@ -1188,8 +1196,8 @@ class LBFGS(Attack):
                               self.batch_size)
 
         def lbfgs_wrap(x_val, y_val):
-            return np.array(attack.attack(x_val, y_val), dtype=np.float32)
-        wrap = tf.py_func(lbfgs_wrap, [x, self.y_target], tf.float32)
+            return np.array(attack.attack(x_val, y_val), dtype=self.np_dtype)
+        wrap = tf.py_func(lbfgs_wrap, [x, self.y_target], self.tf_dtype)
 
         return wrap
 
@@ -1241,20 +1249,20 @@ class MadryEtAl(Attack):
     Paper link: https://arxiv.org/pdf/1706.06083.pdf
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a MadryEtAl instance.
         """
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(MadryEtAl, self).__init__(model, back, sess)
-        self.feedable_kwargs = {'eps': np.float32,
-                                'eps_iter': np.float32,
-                                'y': np.float32,
-                                'y_target': np.float32,
-                                'clip_min': np.float32,
-                                'clip_max': np.float32}
+        super(MadryEtAl, self).__init__(model, back, sess, dtypestr)
+        self.feedable_kwargs = {'eps': self.np_dtype,
+                                'eps_iter': self.np_dtype,
+                                'y': self.np_dtype,
+                                'y_target': self.np_dtype,
+                                'clip_min': self.np_dtype,
+                                'clip_max': self.np_dtype}
         self.structural_kwargs = ['ord', 'nb_iter', 'rand_init']
 
     def generate(self, x, **kwargs):
@@ -1344,7 +1352,7 @@ class MadryEtAl(Attack):
         """
         import tensorflow as tf
         from cleverhans.utils_tf import model_loss, clip_eta
-
+        
         adv_x = x + eta
         preds = self.model.get_probs(adv_x)
         loss = model_loss(y, preds)
@@ -1371,13 +1379,13 @@ class MadryEtAl(Attack):
         """
         import tensorflow as tf
         from cleverhans.utils_tf import clip_eta
-
+        
         if self.rand_init:
-            eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps)
+            eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps, dtype=self.tf_dtype)
             eta = clip_eta(eta, self.ord, self.eps)
         else:
             eta = tf.zeros_like(x)
-
+        
         for i in range(self.nb_iter):
             eta = self.attack_single_step(x, eta, y)
 
@@ -1400,15 +1408,15 @@ class FastFeatureAdversaries(Attack):
     (Kurakin et al. 2016) but applied to the internal representations.
     """
 
-    def __init__(self, model, back='tf', sess=None):
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
         """
         Create a FastFeatureAdversaries instance.
         """
-        super(FastFeatureAdversaries, self).__init__(model, back, sess)
-        self.feedable_kwargs = {'eps': np.float32,
-                                'eps_iter': np.float32,
-                                'clip_min': np.float32,
-                                'clip_max': np.float32,
+        super(FastFeatureAdversaries, self).__init__(model, back, sess, dtypestr)
+        self.feedable_kwargs = {'eps': self.np_dtype,
+                                'eps_iter': self.np_dtype,
+                                'clip_min': self.np_dtype,
+                                'clip_max': self.np_dtype,
                                 'layer': str}
         self.structural_kwargs = ['ord', 'nb_iter']
 
@@ -1517,12 +1525,12 @@ class FastFeatureAdversaries(Attack):
         g_feat = self.model.get_layer(g, self.layer)
 
         # Initialize loop variables
-        eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps)
+        eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps, dtype=tf_dtype)
         eta = clip_eta(eta, self.ord, self.eps)
-
+        
         for i in range(self.nb_iter):
             eta = self.attack_single_step(x, eta, g_feat)
-
+        
         # Define adversarial example (and clip if necessary)
         adv_x = x + eta
         if self.clip_min is not None and self.clip_max is not None:
@@ -1539,8 +1547,8 @@ class SPSA(Attack):
     gradients do not point in useful directions.
     """
 
-    def __init__(self, model, back='tf', sess=None):
-        super(SPSA, self).__init__(model, back, sess)
+    def __init__(self, model, back='tf', sess=None, dtypestr='float32'):
+        super(SPSA, self).__init__(model, back, sess, dtypestr)
         assert isinstance(self.model, Model)
 
     def generate(self, x, y=None, y_target=None, epsilon=None, num_steps=None,

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -28,16 +28,16 @@ class Attack(object):
 
         if back == 'tf':
             import tensorflow as tf
-            self.tf_dtype=tf.as_dtype(dtypestr)
+            self.tf_dtype = tf.as_dtype(dtypestr)
             if sess is None:
                 sess = tf.get_default_session()
-        
-        self.np_dtype=np.dtype(dtypestr)
-        
+
+        self.np_dtype = np.dtype(dtypestr)
+
         import cleverhans.attacks_tf as attacks_tf
-        attacks_tf.np_dtype=self.np_dtype
-        attacks_tf.tf_dtype=self.tf_dtype
-        
+        attacks_tf.np_dtype = self.np_dtype
+        attacks_tf.tf_dtype = self.tf_dtype
+
         if not isinstance(model, Model):
             raise ValueError("The model argument should be an instance of"
                              " the cleverhans.model.Model class.")
@@ -486,7 +486,7 @@ class MomentumIterativeMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(MomentumIterativeMethod, self).__init__(model, back, sess, dtypestr)
+        super().__init__(model, back, sess, dtypestr)
         self.feedable_kwargs = {'eps': self.np_dtype,
                                 'eps_iter': self.np_dtype,
                                 'y': self.np_dtype,
@@ -707,7 +707,8 @@ class SaliencyMapMethod(Attack):
                                       y_target=y_target)
 
                 # Attack is targeted, target placeholder will need to be fed
-                x_adv = tf.py_func(jsma_wrap, [x, self.y_target], self.tf_dtype)
+                x_adv = tf.py_func(jsma_wrap, [x, self.y_target],
+                                   self.tf_dtype)
             else:
                 def jsma_wrap(x_val):
                     return jsma_batch(self.sess, x, preds, grads, x_val,
@@ -768,7 +769,7 @@ class VirtualAdversarialMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
 
-        super(VirtualAdversarialMethod, self).__init__(model, back, sess, dtypestr)
+        super().__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
         self.feedable_kwargs = {'eps': self.tf_dtype, 'xi': self.tf_dtype,
@@ -836,7 +837,7 @@ class CarliniWagnerL2(Attack):
         """
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
-        
+
         super(CarliniWagnerL2, self).__init__(model, back, sess, dtypestr)
 
         import tensorflow as tf
@@ -893,14 +894,14 @@ class CarliniWagnerL2(Attack):
         self.parse_params(**kwargs)
 
         labels, nb_classes = self.get_or_guess_labels(x, kwargs)
-        
+
         attack = CWL2(self.sess, self.model, self.batch_size,
                       self.confidence, 'y_target' in kwargs,
                       self.learning_rate, self.binary_search_steps,
                       self.max_iterations, self.abort_early,
                       self.initial_const, self.clip_min, self.clip_max,
                       nb_classes, x.get_shape().as_list()[1:])
-        
+
         def cw_wrap(x_val, y_val):
             return np.array(attack.attack(x_val, y_val), dtype=self.np_dtype)
         wrap = tf.py_func(cw_wrap, [x, labels], self.tf_dtype)
@@ -1352,7 +1353,7 @@ class MadryEtAl(Attack):
         """
         import tensorflow as tf
         from cleverhans.utils_tf import model_loss, clip_eta
-        
+
         adv_x = x + eta
         preds = self.model.get_probs(adv_x)
         loss = model_loss(y, preds)
@@ -1379,13 +1380,14 @@ class MadryEtAl(Attack):
         """
         import tensorflow as tf
         from cleverhans.utils_tf import clip_eta
-        
+
         if self.rand_init:
-            eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps, dtype=self.tf_dtype)
+            eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps,
+                                    dtype=self.tf_dtype)
             eta = clip_eta(eta, self.ord, self.eps)
         else:
             eta = tf.zeros_like(x)
-        
+
         for i in range(self.nb_iter):
             eta = self.attack_single_step(x, eta, y)
 
@@ -1412,7 +1414,7 @@ class FastFeatureAdversaries(Attack):
         """
         Create a FastFeatureAdversaries instance.
         """
-        super(FastFeatureAdversaries, self).__init__(model, back, sess, dtypestr)
+        super().__init__(model, back, sess, dtypestr)
         self.feedable_kwargs = {'eps': self.np_dtype,
                                 'eps_iter': self.np_dtype,
                                 'clip_min': self.np_dtype,
@@ -1525,12 +1527,13 @@ class FastFeatureAdversaries(Attack):
         g_feat = self.model.get_layer(g, self.layer)
 
         # Initialize loop variables
-        eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps, dtype=tf_dtype)
+        eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps,
+                                dtype=tf_dtype)
         eta = clip_eta(eta, self.ord, self.eps)
-        
+
         for i in range(self.nb_iter):
             eta = self.attack_single_step(x, eta, g_feat)
-        
+
         # Define adversarial example (and clip if necessary)
         adv_x = x + eta
         if self.clip_min is not None and self.clip_max is not None:

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -486,7 +486,8 @@ class MomentumIterativeMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super().__init__(model, back, sess, dtypestr)
+        super(MomentumIterativeMethod, self).__init__(model, back,
+                                                      sess, dtypestr)
         self.feedable_kwargs = {'eps': self.np_dtype,
                                 'eps_iter': self.np_dtype,
                                 'y': self.np_dtype,
@@ -769,7 +770,8 @@ class VirtualAdversarialMethod(Attack):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'logits')
 
-        super().__init__(model, back, sess, dtypestr)
+        super(VirtualAdversarialMethod, self).__init__(model, back,
+                                                       sess, dtypestr)
 
         import tensorflow as tf
         self.feedable_kwargs = {'eps': self.tf_dtype, 'xi': self.tf_dtype,
@@ -1414,7 +1416,8 @@ class FastFeatureAdversaries(Attack):
         """
         Create a FastFeatureAdversaries instance.
         """
-        super().__init__(model, back, sess, dtypestr)
+        super(FastFeatureAdversaries, self).__init__(model, back,
+                                                     sess, dtypestr)
         self.feedable_kwargs = {'eps': self.np_dtype,
                                 'eps_iter': self.np_dtype,
                                 'clip_min': self.np_dtype,

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -1531,7 +1531,7 @@ class FastFeatureAdversaries(Attack):
 
         # Initialize loop variables
         eta = tf.random_uniform(tf.shape(x), -self.eps, self.eps,
-                                dtype=tf_dtype)
+                                dtype=self.tf_dtype)
         eta = clip_eta(eta, self.ord, self.eps)
 
         for i in range(self.nb_iter):

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -14,11 +14,15 @@ from . import utils
 
 _logger = utils.create_logger("cleverhans.attacks.tf")
 
+np_dtype=np.dtype('float32')
+tf_dtype=tf.as_dtype('float32')
+
+def ZERO():
+    return np.asarray(0., dtype=np_dtype)
 
 def fgsm(x, predictions, eps=0.3, clip_min=None, clip_max=None):
     return fgm(x, predictions, y=None, eps=eps, ord=np.inf, clip_min=clip_min,
                clip_max=clip_max)
-
 
 def fgm(x, preds, y=None, eps=0.3, ord=np.inf,
         clip_min=None, clip_max=None,
@@ -119,7 +123,7 @@ def vatm(model, x, logits, eps, num_iterations=1, xi=1e-6,
     :return: a tensor for the adversarial example
     """
     with tf.name_scope(scope, "virtual_adversarial_perturbation"):
-        d = tf.random_normal(tf.shape(x))
+        d = tf.random_normal(tf.shape(x), dtype=tf_dtype)
         for i in range(num_iterations):
             d = xi * utils_tf.l2_batch_normalize(d)
             logits_d = model.get_logits(x + d)
@@ -222,7 +226,7 @@ def jacobian(sess, x, grads, target, X, nb_features, nb_classes, feed=None):
         feed_dict.update(feed)
 
     # Initialize a numpy array to hold the Jacobian component values
-    jacobian_val = np.zeros((nb_classes, nb_features), dtype=np.float32)
+    jacobian_val = np.zeros((nb_classes, nb_features), dtype=np_dtype)
 
     # Compute the gradients for all classes
     for class_ind, grad in enumerate(grads):
@@ -400,7 +404,7 @@ def jsma_batch(sess, x, pred, grads, X, theta, gamma, clip_min, clip_max,
         X_adv[ind], _, _ = jsma(sess, x, pred, grads, val, np.argmax(target),
                                 theta, gamma, clip_min, clip_max, feed=feed)
 
-    return np.asarray(X_adv, dtype=np.float32)
+    return np.asarray(X_adv, dtype=np_dtype)
 
 
 def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
@@ -427,18 +431,18 @@ def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
 
     tmp = np.ones((nb_features, nb_features), int)
     np.fill_diagonal(tmp, 0)
-    zero_diagonal = tf.constant(tmp, tf.float32)
+    zero_diagonal = tf.constant(tmp, tf_dtype)
 
     # Compute our initial search domain. We optimize the initial search domain
     # by removing all features that are already at their maximum values (if
     # increasing input features---otherwise, at their minimum value).
     if increase:
         search_domain = tf.reshape(
-                            tf.cast(x < clip_max, tf.float32),
+                            tf.cast(x < clip_max, tf_dtype),
                             [-1, nb_features])
     else:
         search_domain = tf.reshape(
-                            tf.cast(x > clip_min, tf.float32),
+                            tf.cast(x > clip_min, tf_dtype),
                             [-1, nb_features])
 
     # Loop variables
@@ -473,7 +477,7 @@ def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
         # The last dimention is added to allow broadcasting later.
         target_class = tf.reshape(tf.transpose(y_in, perm=[1, 0]),
                                   shape=[nb_classes, -1, 1])
-        other_classes = tf.cast(tf.not_equal(target_class, 1), tf.float32)
+        other_classes = tf.cast(tf.not_equal(target_class, 1), tf_dtype)
 
         grads_target = tf.reduce_sum(grads * target_class, axis=0)
         grads_other = tf.reduce_sum(grads * other_classes, axis=0)
@@ -482,7 +486,7 @@ def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
         # Subtract 2 times the maximum value from those value so that
         # they won't be picked later
         increase_coef = (4 * int(increase) - 2) \
-            * tf.cast(tf.equal(domain_in, 0), tf.float32)
+            * tf.cast(tf.equal(domain_in, 0), tf_dtype)
 
         target_tmp = grads_target
         target_tmp -= increase_coef \
@@ -503,7 +507,7 @@ def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
             scores_mask = ((target_sum < 0) & (other_sum > 0))
 
         # Create a 2D numpy array of scores for each pair of candidate features
-        scores = tf.cast(scores_mask, tf.float32) \
+        scores = tf.cast(scores_mask, tf_dtype) \
             * (-target_sum * other_sum) * zero_diagonal
 
         # Extract the best two pixels
@@ -521,7 +525,7 @@ def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
         cond = mod_not_done & (tf.reduce_sum(domain_in, axis=1) >= 2)
 
         # Update the search domain
-        cond_float = tf.reshape(tf.cast(cond, tf.float32), shape=[-1, 1])
+        cond_float = tf.reshape(tf.cast(cond, tf_dtype), shape=[-1, 1])
         to_mod = (p1_one_hot + p2_one_hot) * cond_float
 
         domain_out = domain_in - to_mod
@@ -663,22 +667,22 @@ class CarliniWagnerL2(object):
         self.shape = shape = tuple([batch_size] + list(shape))
 
         # the variable we're going to optimize over
-        modifier = tf.Variable(np.zeros(shape, dtype=np.float32))
+        modifier = tf.Variable(np.zeros(shape, dtype=np_dtype))
 
         # these are variables to be more efficient in sending data to tf
-        self.timg = tf.Variable(np.zeros(shape), dtype=tf.float32,
+        self.timg = tf.Variable(np.zeros(shape), dtype=tf_dtype,
                                 name='timg')
         self.tlab = tf.Variable(np.zeros((batch_size, num_labels)),
-                                dtype=tf.float32, name='tlab')
-        self.const = tf.Variable(np.zeros(batch_size), dtype=tf.float32,
+                                dtype=tf_dtype, name='tlab')
+        self.const = tf.Variable(np.zeros(batch_size), dtype=tf_dtype,
                                  name='const')
 
         # and here's what we use to assign them
-        self.assign_timg = tf.placeholder(tf.float32, shape,
+        self.assign_timg = tf.placeholder(tf_dtype, shape,
                                           name='assign_timg')
-        self.assign_tlab = tf.placeholder(tf.float32, (batch_size, num_labels),
+        self.assign_tlab = tf.placeholder(tf_dtype, (batch_size, num_labels),
                                           name='assign_tlab')
-        self.assign_const = tf.placeholder(tf.float32, [batch_size],
+        self.assign_const = tf.placeholder(tf_dtype, [batch_size],
                                            name='assign_const')
 
         # the resulting instance, tanh'd to keep bounded from clip_min
@@ -700,13 +704,13 @@ class CarliniWagnerL2(object):
         other = tf.reduce_max(
             (1 - self.tlab) * self.output - self.tlab * 10000,
             1)
-
+        
         if self.TARGETED:
             # if targeted, optimize for making the other class most likely
-            loss1 = tf.maximum(0.0, other - real + self.CONFIDENCE)
+            loss1 = tf.maximum(ZERO(), other - real + self.CONFIDENCE)
         else:
             # if untargeted, optimize for making this class least likely.
-            loss1 = tf.maximum(0.0, real - other + self.CONFIDENCE)
+            loss1 = tf.maximum(ZERO(), real - other + self.CONFIDENCE)
 
         # sum up the losses
         self.loss2 = tf.reduce_sum(self.l2dist)
@@ -941,40 +945,40 @@ class ElasticNetMethod(object):
 
         self.fista = fista
         self.beta = beta
-        self.beta_t = tf.cast(self.beta, tf.float32)
+        self.beta_t = tf.cast(self.beta, tf_dtype)
 
         self.repeat = binary_search_steps >= 10
 
         self.shape = shape = tuple([batch_size] + list(shape))
 
         # these are variables to be more efficient in sending data to tf
-        self.timg = tf.Variable(np.zeros(shape), dtype=tf.float32,
+        self.timg = tf.Variable(np.zeros(shape), dtype=tf_dtype,
                                 name='timg')
-        self.newimg = tf.Variable(np.zeros(shape), dtype=tf.float32,
+        self.newimg = tf.Variable(np.zeros(shape), dtype=tf_dtype,
                                   name='newimg')
         self.tlab = tf.Variable(np.zeros((batch_size, num_labels)),
-                                dtype=tf.float32, name='tlab')
-        self.const = tf.Variable(np.zeros(batch_size), dtype=tf.float32,
+                                dtype=tf_dtype, name='tlab')
+        self.const = tf.Variable(np.zeros(batch_size), dtype=tf_dtype,
                                  name='const')
 
         # and here's what we use to assign them
-        self.assign_timg = tf.placeholder(tf.float32, shape,
+        self.assign_timg = tf.placeholder(tf_dtype, shape,
                                           name='assign_timg')
-        self.assign_newimg = tf.placeholder(tf.float32, shape,
+        self.assign_newimg = tf.placeholder(tf_dtype, shape,
                                             name='assign_newimg')
-        self.assign_tlab = tf.placeholder(tf.float32, (batch_size,
+        self.assign_tlab = tf.placeholder(tf_dtype, (batch_size,
                                                        num_labels),
                                           name='assign_tlab')
-        self.assign_const = tf.placeholder(tf.float32, [batch_size],
+        self.assign_const = tf.placeholder(tf_dtype, [batch_size],
                                            name='assign_const')
 
         self.global_step = tf.Variable(0, trainable=False)
-        self.global_step_t = tf.cast(self.global_step, tf.float32)
+        self.global_step_t = tf.cast(self.global_step, tf_dtype)
 
         if self.fista:
-            self.slack = tf.Variable(np.zeros(shape), dtype=tf.float32,
+            self.slack = tf.Variable(np.zeros(shape), dtype=tf_dtype,
                                      name='slack')
-            self.assign_slack = tf.placeholder(tf.float32, shape,
+            self.assign_slack = tf.placeholder(tf_dtype, shape,
                                                name='assign_slack')
             var = self.slack
         else:
@@ -983,20 +987,20 @@ class ElasticNetMethod(object):
         """Fast Iterative Shrinkage Thresholding"""
         """--------------------------------"""
         self.zt = tf.divide(self.global_step_t,
-                            self.global_step_t + tf.cast(3, tf.float32))
+                            self.global_step_t + tf.cast(3, tf_dtype))
 
         cond1 = tf.cast(tf.greater(tf.subtract(var, self.timg),
-                                   self.beta_t), tf.float32)
+                                   self.beta_t), tf_dtype)
         cond2 = tf.cast(tf.less_equal(tf.abs(tf.subtract(var,
                                                          self.timg)),
-                                      self.beta_t), tf.float32)
+                                      self.beta_t), tf_dtype)
         cond3 = tf.cast(tf.less(tf.subtract(var, self.timg),
-                                tf.negative(self.beta_t)), tf.float32)
+                                tf.negative(self.beta_t)), tf_dtype)
 
         upper = tf.minimum(tf.subtract(var, self.beta_t),
-                           tf.cast(self.clip_max, tf.float32))
+                           tf.cast(self.clip_max, tf_dtype))
         lower = tf.maximum(tf.add(var, self.beta_t),
-                           tf.cast(self.clip_min, tf.float32))
+                           tf.cast(self.clip_min, tf_dtype))
 
         self.assign_newimg = tf.multiply(cond1, upper)
         self.assign_newimg += tf.multiply(cond2, self.timg)
@@ -1033,10 +1037,10 @@ class ElasticNetMethod(object):
 
         if self.TARGETED:
             # if targeted, optimize for making the other class most likely
-            loss1 = tf.maximum(0.0, other - real + self.CONFIDENCE)
+            loss1 = tf.maximum(ZERO(), other - real + self.CONFIDENCE)
         else:
             # if untargeted, optimize for making this class least likely.
-            loss1 = tf.maximum(0.0, real - other + self.CONFIDENCE)
+            loss1 = tf.maximum(ZERO(), real - other + self.CONFIDENCE)
 
         # sum up the losses
         self.loss21 = tf.reduce_sum(self.l1dist)
@@ -1051,9 +1055,9 @@ class ElasticNetMethod(object):
             other_y = tf.reduce_max((1 - self.tlab) * self.output_y -
                                     (self.tlab * 10000), 1)
             if self.TARGETED:
-                loss1_y = tf.maximum(0.0, other_y - real_y + self.CONFIDENCE)
+                loss1_y = tf.maximum(ZERO(), other_y - real_y + self.CONFIDENCE)
             else:
-                loss1_y = tf.maximum(0.0, real_y - other_y + self.CONFIDENCE)
+                loss1_y = tf.maximum(ZERO(), real_y - other_y + self.CONFIDENCE)
 
             self.loss2_y = tf.reduce_sum(self.l2dist_y)
             self.loss1_y = tf.reduce_sum(self.const * loss1_y)
@@ -1272,7 +1276,7 @@ def deepfool_batch(sess, x, pred, logits, grads, X, nb_candidate, overshoot,
     X_adv = deepfool_attack(sess, x, pred, logits, grads, X, nb_candidate,
                             overshoot, max_iter, clip_min, clip_max, feed=feed)
 
-    return np.asarray(X_adv, dtype=np.float32)
+    return np.asarray(X_adv, dtype=np_dtype)
 
 
 def deepfool_attack(sess, x, predictions, logits, grads, sample, nb_candidate,
@@ -1398,9 +1402,9 @@ class LBFGS_attack(object):
         self.repeat = self.binary_search_steps >= 10
         self.shape = shape = tuple([self.batch_size] +
                                    list(self.x.get_shape().as_list()[1:]))
-        self.ori_img = tf.Variable(np.zeros(self.shape), dtype=tf.float32,
+        self.ori_img = tf.Variable(np.zeros(self.shape), dtype=tf_dtype,
                                    name='ori_img')
-        self.const = tf.Variable(np.zeros(self.batch_size), dtype=tf.float32,
+        self.const = tf.Variable(np.zeros(self.batch_size), dtype=tf_dtype,
                                  name='const')
         self.score = utils_tf.model_loss(self.targeted_label, self.model_preds,
                                          mean=False)
@@ -1634,7 +1638,7 @@ class SPSAAdam(UnrolledAdam):
     def _get_delta(self, x, delta):
         x_shape = x.get_shape().as_list()
         delta_x = delta * tf.sign(tf.random_uniform(
-                [self._num_samples] + x_shape[1:], minval=-1., maxval=1.))
+                [self._num_samples] + x_shape[1:], minval=-1., maxval=1., dtype=tf_dtype))
         return delta_x
 
     def _compute_gradients(self, loss_fn, x, unused_optim_state):
@@ -1662,7 +1666,7 @@ class SPSAAdam(UnrolledAdam):
         _, all_grads = tf.while_loop(
                 cond, body,
                 loop_vars=[0, tf.TensorArray(size=self._num_iters,
-                           dtype=tf.float32)],
+                           dtype=tf_dtype)],
                 back_prop=False, parallel_iterations=1)
         avg_grad = tf.reduce_sum(all_grads.stack(), axis=0)
         return [avg_grad]
@@ -1711,7 +1715,7 @@ def pgd_attack(loss_fn, input_image, label, epsilon, num_steps,
     """
 
     init_perturbation = tf.random_uniform(tf.shape(input_image),
-                                          minval=-epsilon, maxval=epsilon)
+                                          minval=-epsilon, maxval=epsilon, dtype=tf_dtype)
     init_perturbation = project_perturbation(init_perturbation,
                                              epsilon, input_image)
     init_optim_state = optimizer.init_state([init_perturbation])

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -14,15 +14,18 @@ from . import utils
 
 _logger = utils.create_logger("cleverhans.attacks.tf")
 
-np_dtype=np.dtype('float32')
-tf_dtype=tf.as_dtype('float32')
+np_dtype = np.dtype('float32')
+tf_dtype = tf.as_dtype('float32')
+
 
 def ZERO():
     return np.asarray(0., dtype=np_dtype)
 
+
 def fgsm(x, predictions, eps=0.3, clip_min=None, clip_max=None):
     return fgm(x, predictions, y=None, eps=eps, ord=np.inf, clip_min=clip_min,
                clip_max=clip_max)
+
 
 def fgm(x, preds, y=None, eps=0.3, ord=np.inf,
         clip_min=None, clip_max=None,
@@ -704,7 +707,7 @@ class CarliniWagnerL2(object):
         other = tf.reduce_max(
             (1 - self.tlab) * self.output - self.tlab * 10000,
             1)
-        
+
         if self.TARGETED:
             # if targeted, optimize for making the other class most likely
             loss1 = tf.maximum(ZERO(), other - real + self.CONFIDENCE)
@@ -966,8 +969,7 @@ class ElasticNetMethod(object):
                                           name='assign_timg')
         self.assign_newimg = tf.placeholder(tf_dtype, shape,
                                             name='assign_newimg')
-        self.assign_tlab = tf.placeholder(tf_dtype, (batch_size,
-                                                       num_labels),
+        self.assign_tlab = tf.placeholder(tf_dtype, (batch_size, num_labels),
                                           name='assign_tlab')
         self.assign_const = tf.placeholder(tf_dtype, [batch_size],
                                            name='assign_const')
@@ -1055,9 +1057,11 @@ class ElasticNetMethod(object):
             other_y = tf.reduce_max((1 - self.tlab) * self.output_y -
                                     (self.tlab * 10000), 1)
             if self.TARGETED:
-                loss1_y = tf.maximum(ZERO(), other_y - real_y + self.CONFIDENCE)
+                loss1_y = tf.maximum(ZERO(),
+                                     other_y - real_y + self.CONFIDENCE)
             else:
-                loss1_y = tf.maximum(ZERO(), real_y - other_y + self.CONFIDENCE)
+                loss1_y = tf.maximum(ZERO(),
+                                     real_y - other_y + self.CONFIDENCE)
 
             self.loss2_y = tf.reduce_sum(self.l2dist_y)
             self.loss1_y = tf.reduce_sum(self.const * loss1_y)
@@ -1638,7 +1642,8 @@ class SPSAAdam(UnrolledAdam):
     def _get_delta(self, x, delta):
         x_shape = x.get_shape().as_list()
         delta_x = delta * tf.sign(tf.random_uniform(
-                [self._num_samples] + x_shape[1:], minval=-1., maxval=1., dtype=tf_dtype))
+                [self._num_samples] + x_shape[1:],
+                minval=-1., maxval=1., dtype=tf_dtype))
         return delta_x
 
     def _compute_gradients(self, loss_fn, x, unused_optim_state):
@@ -1715,7 +1720,8 @@ def pgd_attack(loss_fn, input_image, label, epsilon, num_steps,
     """
 
     init_perturbation = tf.random_uniform(tf.shape(input_image),
-                                          minval=-epsilon, maxval=epsilon, dtype=tf_dtype)
+                                          minval=-epsilon, maxval=epsilon,
+                                          dtype=tf_dtype)
     init_perturbation = project_perturbation(init_perturbation,
                                              epsilon, input_image)
     init_optim_state = optimizer.init_state([init_perturbation])


### PR DESCRIPTION
attack.py contains the classes for all the supported adversarial attacks. In the init of the attack classes has been added a variable `dtypestr` the strting of the dtype wanted. This will be converted in np_dtype and tf_dtype and stored in the attack class, so that can be used in the following methods: `generate` and `generate_np`..

also attack_tf.py was modified for this purpose. This python file is less organized so instead of passing a dtype around following the flow of the functions calls, I added global variables tf_dtype and np_dtype of the module.

The code has been tested and as far as I could see all attacks are working properly in both float32 and float64.