### PR TITLE
switch mnist dataset to datapythonista/mnist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service scikit-learn
   - source activate test-environment
 
   # install TensorFlow

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
     fi
-  - pip install -q -e ".[test]"
+  - time pip install -q -e ".[test]"
 
   # workaround for version incompatibility between the scipy version in conda
   # and the system-provided /usr/lib/x86_64-linux-gnu/libstdc++.so.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
     fi
-  - pip install -e ".[test]"
+  - pip install -q -e ".[test]"
 
   # workaround for version incompatibility between the scipy version in conda
   # and the system-provided /usr/lib/x86_64-linux-gnu/libstdc++.so.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service scikit-learn
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pyqt=4.11 matplotlib pandas h5py six mkl-service
   - source activate test-environment
 
   # install TensorFlow

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,7 @@ install:
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
     fi
-  - pip install keras==2.1.5
-  - python setup.py install
+  - pip install -e ".[test]"
 
   # workaround for version incompatibility between the scipy version in conda
   # and the system-provided /usr/lib/x86_64-linux-gnu/libstdc++.so.6

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-import sys
-import warnings
 
 from . import utils
 
@@ -27,17 +25,26 @@ def data_mnist(datadir='/tmp/', train_start=0, train_end=60000, test_start=0,
     assert isinstance(test_start, int)
     assert isinstance(test_end, int)
 
-    from tensorflow.examples.tutorials.mnist import input_data
-    mnist = input_data.read_data_sets(datadir, one_hot=True, reshape=False)
-    X_train = np.vstack((mnist.train.images, mnist.validation.images))
-    Y_train = np.vstack((mnist.train.labels, mnist.validation.labels))
-    X_test = mnist.test.images
-    Y_test = mnist.test.labels
+    from sklearn.datasets import fetch_mldata
+    mnist = fetch_mldata('MNIST original', data_home=datadir)
+    X_train = mnist.data[:60000] / 255.
+    Y_train = mnist.target[:60000]
+    X_test = mnist.data[60000:] / 255.
+    Y_test = mnist.target[60000:]
+
+    X_train = np.reshape(X_train, (60000, 28, 28, 1))
+    X_test = np.reshape(X_test, (10000, 28, 28, 1))
+
+    print(X_train.max())
+    print(X_train.min())
 
     X_train = X_train[train_start:train_end]
     Y_train = Y_train[train_start:train_end]
     X_test = X_test[test_start:test_end]
     Y_test = Y_test[test_start:test_end]
+
+    Y_train = utils.to_categorical(Y_train, num_classes=10)
+    Y_test = utils.to_categorical(Y_test, num_classes=10)
 
     print('X_train shape:', X_train.shape)
     print('X_test shape:', X_test.shape)

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -25,16 +25,12 @@ def data_mnist(datadir='/tmp/', train_start=0, train_end=60000, test_start=0,
     assert isinstance(test_start, int)
     assert isinstance(test_end, int)
 
-    import torchvision
-    train_dataset = torchvision.datasets.MNIST(
-        root=datadir, train=True, download=True)
-    test_dataset = torchvision.datasets.MNIST(
-        root=datadir, train=False, download=True)
+    import mnist
 
-    X_train = train_dataset.train_data.numpy() / 255.
-    Y_train = train_dataset.train_labels.numpy()
-    X_test = test_dataset.test_data.numpy() / 255.
-    Y_test = test_dataset.test_labels.numpy()
+    X_train = mnist.train_images() / 255.
+    Y_train = mnist.train_labels()
+    X_test = mnist.test_images() / 255.
+    Y_test = mnist.test_labels()
 
     X_train = np.expand_dims(X_train, -1)
     X_test = np.expand_dims(X_test, -1)

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -35,9 +35,6 @@ def data_mnist(datadir='/tmp/', train_start=0, train_end=60000, test_start=0,
     X_train = np.expand_dims(X_train, -1)
     X_test = np.expand_dims(X_test, -1)
 
-    print(X_train.max())
-    print(X_train.min())
-
     X_train = X_train[train_start:train_end]
     Y_train = Y_train[train_start:train_end]
     X_test = X_test[test_start:test_end]

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -42,8 +42,4 @@ def data_mnist(datadir='/tmp/', train_start=0, train_end=60000, test_start=0,
 
     Y_train = utils.to_categorical(Y_train, num_classes=10)
     Y_test = utils.to_categorical(Y_test, num_classes=10)
-
-    print('X_train shape:', X_train.shape)
-    print('X_test shape:', X_test.shape)
-
     return X_train, Y_train, X_test, Y_test

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -25,15 +25,19 @@ def data_mnist(datadir='/tmp/', train_start=0, train_end=60000, test_start=0,
     assert isinstance(test_start, int)
     assert isinstance(test_end, int)
 
-    from sklearn.datasets import fetch_mldata
-    mnist = fetch_mldata('MNIST original', data_home=datadir)
-    X_train = mnist.data[:60000] / 255.
-    Y_train = mnist.target[:60000]
-    X_test = mnist.data[60000:] / 255.
-    Y_test = mnist.target[60000:]
+    import torchvision
+    train_dataset = torchvision.datasets.MNIST(
+        root=datadir, train=True, download=True)
+    test_dataset = torchvision.datasets.MNIST(
+        root=datadir, train=False, download=True)
 
-    X_train = np.reshape(X_train, (60000, 28, 28, 1))
-    X_test = np.reshape(X_test, (10000, 28, 28, 1))
+    X_train = train_dataset.train_data.numpy() / 255.
+    Y_train = train_dataset.train_labels.numpy()
+    X_test = test_dataset.test_data.numpy() / 255.
+    Y_test = test_dataset.test_labels.numpy()
+
+    X_train = np.expand_dims(X_train, -1)
+    X_test = np.expand_dims(X_test, -1)
 
     print(X_train.max())
     print(X_train.min())

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-from setuptools import setup
 from setuptools import find_packages
-
+from setuptools import setup
 
 setup(name='cleverhans',
       version='2.0.0',
@@ -14,7 +13,11 @@ setup(name='cleverhans',
       # Explicit dependence on TensorFlow is not supported.
       # See https://github.com/tensorflow/tensorflow/issues/7166
       extras_require={
-        "tf": ["tensorflow>=1.0.0"],
-        "tf_gpu": ["tensorflow-gpu>=1.0.0"],
+          "tf": ["tensorflow>=1.0.0"],
+          "tf_gpu": ["tensorflow-gpu>=1.0.0"],
+          "test": [
+              "keras ~= 2.1",  # For keras tests
+              "torchvision ~= 0.2",  # for mnist dataset
+          ],
       },
       packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='cleverhans',
           "tf_gpu": ["tensorflow-gpu>=1.0.0"],
           "test": [
               "keras ~= 2.1",  # For keras tests
-              "torchvision ~= 0.2",  # for mnist dataset
+              "mnist ~= 0.2",
           ],
       },
       packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='cleverhans',
           "tf": ["tensorflow>=1.0.0"],
           "tf_gpu": ["tensorflow-gpu>=1.0.0"],
           "test": [
-              "keras ~= 2.1",  # For keras tests
+              "keras ~= 2.1.5",  # For keras tests
               "mnist ~= 0.2",
           ],
       },

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='cleverhans',
           "tf": ["tensorflow>=1.0.0"],
           "tf_gpu": ["tensorflow-gpu>=1.0.0"],
           "test": [
-              "keras ~= 2.1.5",  # For keras tests
+              "keras == 2.1.5",  # Keras 2.1.6 is incompatible with TF 1.4
               "mnist ~= 0.2",
           ],
       },


### PR DESCRIPTION
A recent change to the TF API creates a deprecation warning because CleverHans uses the MNIST dataset loader that comes with `tf.learn`.

This implements the suggested switch to `sklearn` as the data loader. 