### PR TITLE
Improve utils_tf.model_train 's functionality and solve several tensorflow version issues

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -213,7 +213,7 @@ class Attack(object):
             labels = kwargs['y_target']
         else:
             preds = self.model.get_probs(x)
-            preds_max = tf.reduce_max(preds, 1, keep_dims=True)
+            preds_max = tf.reduce_max(preds, 1, keepdims=True)
             original_predictions = tf.to_float(tf.equal(preds,
                                                         preds_max))
             labels = tf.stop_gradient(original_predictions)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -387,7 +387,7 @@ class BasicIterativeMethod(Attack):
 
         # Fix labels to the first model predictions for loss computation
         model_preds = self.model.get_probs(x)
-        preds_max = tf.reduce_max(model_preds, 1, keep_dims=True)
+        preds_max = tf.reduce_max(model_preds, 1, keepdims=True)
         if self.y_target is not None:
             y = self.y_target
             targeted = True

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -100,8 +100,8 @@ def model_train(sess, x, y, predictions, X_train, Y_train, dataflow=None,
 
     # Check that necessary arguments were given (see doc above)
     assert args.nb_epochs, "Number of epochs was not given in args dict"
-    assert args.learning_rate, "Learning rate was not given in args dict"
     assert args.batch_size, "Batch size was not given in args dict"
+    assert args.learning_rate is not None, "Learning rate was not given in args dict"
 
     if save:
         assert args.train_dir, "Directory for save was not given in args dict"

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -130,6 +130,8 @@ def model_train(sess, x, y, predictions, X_train, Y_train, dataflow=None,
             sess.run(tf.initialize_all_variables())
 
         for epoch in xrange(args.nb_epochs):
+            sess.run(tf.assign(args.epoch_step, epoch))
+
             # Compute number of batches
             nb_batches = int(math.ceil(float(len(X_train)) / args.batch_size))
             assert nb_batches * args.batch_size >= len(X_train)


### PR DESCRIPTION
1. `model_train` now accept training data iterator as an argument, supporting some real-time data augmentation schemes such as ImageDataGenerator in Keras.
2. `model_train` can now train with weight decay by simply passing the scale of decay as an argument.
3. `model_train` now additionally log the current learning rate (in case learning rate decay is applied).
4. Fix several tensorflow warnings about deprecated usage.