### PR TITLE
Fix to separate training of oracle from substitute model

### DIFF
--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -74,7 +74,7 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
         'learning_rate': learning_rate
     }
     model_train(sess, x, y, predictions, X_train, Y_train,
-                args=train_params, rng=rng)
+                args=train_params, rng=rng, var_list=model.get_params())
 
     # Print out the accuracy on legitimate data
     eval_params = {'batch_size': batch_size}
@@ -149,7 +149,8 @@ def train_sub(sess, x, y, bbox_preds, X_sub, Y_sub, nb_classes,
         with TemporaryLogLevel(logging.WARNING, "cleverhans.utils.tf"):
             model_train(sess, x, y, preds_sub, X_sub,
                         to_categorical(Y_sub, nb_classes),
-                        init_all=False, args=train_params, rng=rng)
+                        init_all=False, args=train_params, rng=rng,
+                        var_list=model_sub.get_params())
 
         # If we are not at last substitute training iteration, augment dataset
         if rho < data_aug - 1:


### PR DESCRIPTION
Fix for Substitute training optimizes for both BlackBox variables and Substitute variables #400