### PR TITLE
Fixed grammar for Value Error

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -24,7 +24,7 @@ class Attack(object):
         :param sess: The tf session to run graphs in
         """
         if not(back == 'tf'):
-            raise ValueError("Backend argument must either be 'tf'.")
+            raise ValueError("Backend argument must be 'tf'.")
 
         if back == 'tf':
             import tensorflow as tf


### PR DESCRIPTION
Since Tensorflow is the only option the previous sentence was "Backend argument must either be 'tf'.", but that was grammatically incorrect because Tensorflow was the only option, so the I removed the either so the sentence is now "Backend argument must be 'tf'."