### PR TITLE
added eager tutorial and attacks.

### DIFF
--- a/cleverhans/attacks_tfe.py
+++ b/cleverhans/attacks_tfe.py
@@ -1,0 +1,197 @@
+from abc import ABCMeta
+import numpy as np
+from six.moves import xrange
+import warnings
+import collections
+import tensorflow as tf
+
+from distutils.version import LooseVersion
+import cleverhans.utils as utils
+from cleverhans.attacks import Attack
+from cleverhans.attacks import FastGradientMethod
+from cleverhans.model import Model
+from cleverhans.loss import LossCrossEntropy
+
+_logger = utils.create_logger("cleverhans.attacks_tfe")
+
+
+if LooseVersion(tf.__version__) < LooseVersion('1.8.0'):
+    error = ('For eager execution',
+             'use Tensorflow version greather than 1.8.0.')
+    raise ValueError(error)
+
+
+class AttackTFE(Attack):
+    """
+    Abstract base class for all eager attack classes.
+    """
+
+    def __init__(self, model, dtypestr='float32'):
+        """
+        :param model: An instance of the cleverhans.model.Model class.
+        :param back: The backend to use. Inherited from AttackBase class.
+        :param dtypestr: datatype of the input data samples and crafted
+                        adversarial attacks.
+        """
+        # Validate the input arguments.
+        if dtypestr != 'float32' and dtypestr != 'float64':
+            raise ValueError("Unexpected input for argument dtypestr.")
+        import tensorflow as tf
+        tfe = tf.contrib.eager
+        self.tf_dtype = tf.as_dtype(dtypestr)
+        self.np_dtype = np.dtype(dtypestr)
+
+        if not isinstance(model, Model):
+            raise ValueError("The model argument should be an instance of"
+                             " the cleverhans.model.Model class.")
+        # Prepare attributes
+        self.model = model
+        self.dtypestr = dtypestr
+
+    def consturct_graph(self, **kwargs):
+        """
+        Constructs the graph required to run the attacks.
+        Is inherited from the attack class, is overloaded
+        to raise an error.
+        """ 
+        error = "This method is not required for eager execution."
+        raise AttributeError(error)
+
+    def generate_np(self, x_val, **kwargs):
+        """
+        Generate adversarial examples and return them as a NumPy array.
+
+        :param x_val: A NumPy array with the original inputs.
+        :param **kwargs: optional parameters used by child classes.
+        :return: A NumPy array holding the adversarial examples.
+        """
+        tfe = tf.contrib.eager
+        x = tfe.Variable(x_val)
+        adv_x = self.generate(x, **kwargs)
+        return adv_x.numpy()
+
+    def construct_variables(self, kwargs):
+        """
+        Construct the inputs to the attack graph.
+        Is inherited from the attack class, is overloaded
+        to raise an error.
+        """
+        error = "This method is not required for eager execution."
+        raise AttributeError(error)
+
+
+
+class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
+    """
+    Inherited class from AttackTFE and FastGradientMethod.
+
+    This attack was originally implemented by Goodfellow et al. (2015) with the
+    infinity norm (and is known as the "Fast Gradient Sign Method"). This
+    implementation extends the attack to other norms, and is therefore called
+    the Fast Gradient Method.
+    Paper link: https://arxiv.org/abs/1412.6572
+    """
+    def __init__(self, model, dtypestr='float32'):
+        """
+        Creates a FastGradientMethodTFE instance.
+        :model: CNN netwok, should be an instance of 
+                cleverhans.model.Model, if not wrap 
+                the output to probs.
+        :dtypestr: datatype in the string format.
+        """
+        if not isinstance(model, Model):
+            model = CallableModelWrapper(model, 'probs')
+
+        super(FastGradientMethodTFE, self).__init__(model, dtypestr)
+
+    def generate(self, x, **kwargs):
+        """
+        Generates the adversarial sample for the given input.
+
+        :param x: The model's inputs.
+        :param eps: (optional float) attack step size (input variation)
+        :param ord: (optional) Order of the norm (mimics NumPy).
+                    Possible values: np.inf, 1 or 2.
+        :param y: (optional) A tf variable` with the model labels. Only provide
+                  this parameter if you'd like to use true labels when crafting
+                  adversarial samples. Otherwise, model predictions are used as
+                  labels to avoid the "label leaking" effect (explained in this
+                  paper: https://arxiv.org/abs/1611.01236). Default is None.
+                  Labels should be one-hot-encoded.
+        :param y_target: (optional) A tf variable` with the labels to target.
+                            Leave y_target=None if y is also set.
+                            Labels should be one-hot-encoded.
+        :param clip_min: (optional float) Minimum input component value
+        :param clip_max: (optional float) Maximum input component value
+        """
+        # Parse and save attack-specific parameters
+        assert self.parse_params(**kwargs)
+        labels, nb_classes = self.get_or_guess_labels(x, kwargs)
+        return self.fgm(x, labels=labels, targeted=(self.y_target is not None))
+
+    def fgm(self, x, labels, targeted=False):
+        """
+        TensorFlow Eager implementation of the Fast Gradient Method.
+        :param x: the input variable
+        :param targeted: Is the attack targeted or untargeted? Untargeted, the
+                         default, will try to make the label incorrect.
+                         Targeted will instead try to move in the direction
+                         of being more like y.
+        :return: a tensor for the adversarial example
+        """
+        # Compute loss
+        with tf.GradientTape() as tape:
+            loss_obj = LossCrossEntropy(self.model, smoothing=0.)
+            loss = loss_obj.fprop(x=x, y=labels)
+            if targeted:
+                loss = -loss
+
+        # Define gradient of loss wrt input
+        grad = tape.gradient(loss, x)
+        if self.ord == np.inf:
+            # Take sign of gradient
+            normalized_grad = tf.sign(grad)
+            # The following line should not change the numerical results.
+            # It applies only because `normalized_grad` is the output of
+            # a `sign` op, which has zero derivative anyway.
+            # It should not be applied for the other norms, where the
+            # perturbation has a non-zero derivative.
+            normalized_grad = tf.stop_gradient(normalized_grad)
+        elif self.ord == 1:
+            red_ind = list(xrange(1, len(x.get_shape())))
+            normalized_grad = grad / tf.reduce_sum(tf.abs(grad),
+                                                   reduction_indices=red_ind,
+                                                   keep_dims=True)
+        elif self.ord == 2:
+            red_ind = list(xrange(1, len(x.get_shape())))
+            square = tf.reduce_sum(tf.square(grad),
+                                   reduction_indices=red_ind,
+                                   keep_dims=True)
+            normalized_grad = grad / tf.sqrt(square)
+        else:
+            raise NotImplementedError("Only L-inf, L1 and L2 norms are "
+                                      "currently implemented.")
+
+        # Multiply by constant epsilon
+        scaled_grad = self.eps * normalized_grad
+
+        # Add perturbation to original example to obtain adversarial example
+        adv_x = x + scaled_grad
+
+        # If clipping is needed
+        # reset all values outside of [clip_min, clip_max]
+        if (self.clip_min is not None) and (self.clip_max is not None):
+            adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
+        return adv_x
+
+if __name__ == "__main__":
+    from cleverhans_tutorials.tutorial_models_tfe import ModelBasicCNNTFE
+    model = ModelBasicCNNTFE()
+    fgsm = FastGradientMethodTFE(model)
+    tfe = tf.contrib.eager
+    inp = tfe.Variable(tf.ones((32,32, 32, 1)))
+    pertubation = fgsm.generate(inp)
+    import matplotlib.pyplot as plt
+    print(pertubation.shape)
+    plt.imshow(pertubation[0,:,:,0])
+    plt.show()

--- a/cleverhans/attacks_tfe.py
+++ b/cleverhans/attacks_tfe.py
@@ -53,7 +53,7 @@ class AttackTFE(Attack):
         Constructs the graph required to run the attacks.
         Is inherited from the attack class, is overloaded
         to raise an error.
-        """ 
+        """
         error = "This method is not required for eager execution."
         raise AttributeError(error)
 
@@ -80,7 +80,6 @@ class AttackTFE(Attack):
         raise AttributeError(error)
 
 
-
 class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
     """
     Inherited class from AttackTFE and FastGradientMethod.
@@ -94,8 +93,8 @@ class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
     def __init__(self, model, dtypestr='float32'):
         """
         Creates a FastGradientMethodTFE instance.
-        :model: CNN netwok, should be an instance of 
-                cleverhans.model.Model, if not wrap 
+        :model: CNN netwok, should be an instance of
+                cleverhans.model.Model, if not wrap
                 the output to probs.
         :dtypestr: datatype in the string format.
         """
@@ -183,15 +182,3 @@ class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
         if (self.clip_min is not None) and (self.clip_max is not None):
             adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
         return adv_x
-
-if __name__ == "__main__":
-    from cleverhans_tutorials.tutorial_models_tfe import ModelBasicCNNTFE
-    model = ModelBasicCNNTFE()
-    fgsm = FastGradientMethodTFE(model)
-    tfe = tf.contrib.eager
-    inp = tfe.Variable(tf.ones((32,32, 32, 1)))
-    pertubation = fgsm.generate(inp)
-    import matplotlib.pyplot as plt
-    print(pertubation.shape)
-    plt.imshow(pertubation[0,:,:,0])
-    plt.show()

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -56,7 +56,7 @@ class LossCrossEntropy(Loss):
         else:
             x = x,
 
-        # Catching RuntimeError: Variable -= value not supported.
+        # Catching RuntimeError: Variable -= value not supported by tf.eager.
         try:
             y -= self.smoothing * (y - 1. / tf.cast(y.shape[-1], tf.float32))
         except RuntimeError:

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -55,7 +55,7 @@ class LossCrossEntropy(Loss):
             x = x, self.attack(x)
         else:
             x = x,
-        y -= self.smoothing * (y - 1. / tf.cast(y.shape[-1], tf.float32))
+        #y -= self.smoothing * (y - 1. / tf.cast(y.shape[-1], tf.float32))
         logits = [self.model.get_logits(x, **kwargs) for x in x]
         loss = sum(
             tf.nn.softmax_cross_entropy_with_logits(labels=y, logits=logit)

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -55,7 +55,14 @@ class LossCrossEntropy(Loss):
             x = x, self.attack(x)
         else:
             x = x,
-        #y -= self.smoothing * (y - 1. / tf.cast(y.shape[-1], tf.float32))
+
+        # Catching RuntimeError: Variable -= value not supported.
+        try:
+            y -= self.smoothing * (y - 1. / tf.cast(y.shape[-1], tf.float32))
+        except RuntimeError:
+            y.assign_sub(self.smoothing * (y - 1. / tf.cast(y.shape[-1],
+                                                            tf.float32)))
+
         logits = [self.model.get_logits(x, **kwargs) for x in x]
         loss = sum(
             tf.nn.softmax_cross_entropy_with_logits(labels=y, logits=logit)

--- a/cleverhans/model.py
+++ b/cleverhans/model.py
@@ -68,8 +68,12 @@ class Model(object):
         Provides access to the model's parameters.
         :return: A list of all Variables defining the model parameters.
         """
-        scope_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                       self.scope)
+        if tf.executing_eagerly() == False:
+            scope_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                           self.scope)
+        else:
+            error = 'For Eager execution - get_params must be overridden.'
+            raise NotImplementedError()
         return scope_vars
 
     def get_layer_names(self):

--- a/cleverhans/model.py
+++ b/cleverhans/model.py
@@ -69,14 +69,17 @@ class Model(object):
         Provides access to the model's parameters.
         :return: A list of all Variables defining the model parameters.
         """
-        # For tf 1.4 - in which executing_eagerly throws an error.
+        # Catch eager execution and assert function overload.
         try:
             if tf.executing_eagerly():
                 raise NotImplementedError("For Eager execution - get_params "
                                           "must be overridden.")
         except AttributeError:
-            scope_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                           self.scope)
+            pass
+
+        # For Graoh based execution
+        scope_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                       self.scope)
         return scope_vars
 
     def get_layer_names(self):

--- a/cleverhans/model.py
+++ b/cleverhans/model.py
@@ -68,12 +68,12 @@ class Model(object):
         Provides access to the model's parameters.
         :return: A list of all Variables defining the model parameters.
         """
-        if tf.executing_eagerly() == False:
+        if tf.executing_eagerly():
+            raise NotImplementedError("For Eager execution - get_params must "
+                                      "be overridden.")
+        else:
             scope_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
                                            self.scope)
-        else:
-            error = 'For Eager execution - get_params must be overridden.'
-            raise NotImplementedError()
         return scope_vars
 
     def get_layer_names(self):

--- a/cleverhans/model.py
+++ b/cleverhans/model.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta
 import tensorflow as tf
+from distutils.version import LooseVersion
 
 
 class Model(object):
@@ -68,10 +69,12 @@ class Model(object):
         Provides access to the model's parameters.
         :return: A list of all Variables defining the model parameters.
         """
-        if tf.executing_eagerly():
-            raise NotImplementedError("For Eager execution - get_params must "
-                                      "be overridden.")
-        else:
+        # For tf 1.4 - in which executing_eagerly throws an error.
+        try:
+            if tf.executing_eagerly():
+                raise NotImplementedError("For Eager execution - get_params "
+                                          "must be overridden.")
+        except AttributeError:
             scope_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
                                            self.scope)
         return scope_vars

--- a/cleverhans/utils_tfe.py
+++ b/cleverhans/utils_tfe.py
@@ -1,0 +1,232 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+import math
+import numpy as np
+import os
+import tensorflow as tf
+import time
+import warnings
+from six.moves import xrange
+
+from distutils.version import LooseVersion
+from cleverhans.loss import LossCrossEntropy
+from .utils import batch_indices, _ArgsWrapper, create_logger
+
+_logger = create_logger("cleverhans.utils.tfe")
+
+
+def train(model, X_train=None, Y_train=None, save=False,
+                predictions_adv=None, evaluate=None,
+                args=None, rng=None, var_list=None,
+                attack=None, attack_args=None):
+    """
+    Train a TF Eager model
+    :param model: instance of cleverhans model, takes in input batch,
+                    gives out probs(softmax layer).
+    :param X_train: numpy array with training inputs
+    :param Y_train: numpy array with training outputs
+    :param save: boolean controlling the save operation
+    :param predictions_adv: if set with the adversarial example tensor,
+                            will run adversarial training
+    :param evaluate: function that is run after each training iteration
+                     (typically to display the test/validation accuracy).
+    :param args: dict or argparse `Namespace` object.
+                 Should contain `nb_epochs`, `learning_rate`,
+                 `batch_size`
+                 If save is True, should also contain 'train_dir'
+                 and 'filename'
+    :param rng: Instance of numpy.random.RandomState
+    :param var_list: List of variables to train.
+    :param attack: Instance of the class cleverhans.attacks.attacks_eager
+    :param attack_args: Parameters required for the attack.
+    :return: True if model trained
+    """
+    args = _ArgsWrapper(args or {})
+    if ((attack is None) != (attack_args is None)):
+        error = "attack and attack_args must be passed together."
+        raise ValueError(error)
+    if X_train is None or Y_train is None:
+        raise ValueError("X_train argument and Y_train argument "
+                         "must be supplied.")
+    # Check that necessary arguments were given (see doc above)
+    assert args.nb_epochs, "Number of epochs was not given in args dict"
+    assert args.learning_rate, "Learning rate was not given in args dict"
+    assert args.batch_size, "Batch size was not given in args dict"
+
+    if save:
+        assert args.train_dir, "Directory for save was not given in args dict"
+        assert args.filename, "Filename for save was not given in args dict"
+
+    if rng is None:
+        rng = np.random.RandomState()
+
+    # Optimizer
+    tfe = tf.contrib.eager
+    optimizer = tf.train.AdamOptimizer(learning_rate=args.learning_rate)
+    batch_x = tfe.Variable(X_train[0:args.batch_size], dtype=tf.float32)
+    batch_y = tfe.Variable(Y_train[0:args.batch_size], dtype=tf.float32)
+
+    # One epoch of training.
+    for epoch in xrange(args.nb_epochs):
+        # Compute number of batches
+        nb_batches = int(math.ceil(float(len(X_train)) / args.batch_size))
+        assert nb_batches * args.batch_size >= len(X_train)
+
+        # Indices to shuffle training set
+        index_shuf = list(range(len(X_train)))
+        rng.shuffle(index_shuf)
+
+        prev = time.time()
+        for batch in range(nb_batches):
+
+            # Compute batch start and end indices
+            start, end = batch_indices(
+                batch, len(X_train), args.batch_size)
+
+            # Perform one training step
+            tf.assign(batch_x, X_train[index_shuf[start:end]])
+            tf.assign(batch_y, Y_train[index_shuf[start:end]])
+            # Compute grads
+            with tf.GradientTape() as tape:
+                # Define loss
+                loss_clean_obj = LossCrossEntropy(model, smoothing=0.)
+                loss_clean = loss_clean_obj.fprop(x=batch_x, y=batch_y)
+                loss = loss_clean
+                # Adversarial training
+                if attack is not None:
+                    batch_adv_x = attack.generate(batch_x, **attack_args)
+                    loss_adv_obj = LossCrossEntropy(model, smoothing=0.)
+                    loss_adv = loss_adv_obj.fprop(x=batch_adv_x, y=batch_y)
+                    loss = (loss_clean + loss_adv) / 2.0
+            # Apply grads
+            model_variables = model.get_params()
+            grads = tape.gradient(loss, model_variables)
+            optimizer.apply_gradients(zip(grads, model_variables))
+
+        assert end >= len(X_train)  # Check that all examples were used
+        cur = time.time()
+        _logger.info("Epoch " + str(epoch) + " took " +
+                     str(cur - prev) + " seconds")
+        if evaluate is not None:
+            evaluate()
+
+    if save:
+        save_path = os.path.join(args.train_dir, args.filename)
+        saver = tf.train.Saver()
+        saver.save(save_path, model_variables)
+        _logger.info("Completed model training and saved at: " +
+                     str(save_path))
+    else:
+        _logger.info("Completed model training.")
+
+    return True
+
+
+def model_eval(model, X_test=None, Y_test=None, args=None,
+               attack=None, attack_args=None):
+    """
+    Compute the accuracy of a TF Eager model on some data
+    :param model: instance of cleverhans.model.Model_Eager
+                    with pretrained weights for evaluation.
+    :param X_test: numpy array with training inputs
+    :param Y_test: numpy array with training outputs
+    :param args: dict or argparse `Namespace` object.
+                 Should contain `batch_size`
+    :param attack: instance of the class cleverhans.attacks.attacks_eager
+    :param attack_args: parameters required for the attack.
+    :return: a float with the accuracy value
+    """
+    args = _ArgsWrapper(args or {})
+
+    if ((attack is None) != (attack_args is None)):
+        error = "attack and attack_args must be passed together."
+        raise ValueError(error)
+    assert args.batch_size, "Batch size was not given in args dict"
+    if X_test is None or Y_test is None:
+        raise ValueError("X_test argument and Y_test argument "
+                         "must be supplied.")
+
+    # Define accuracy symbolically
+    if LooseVersion(tf.__version__) <= LooseVersion('1.0.0'):
+        raise Exception('Use Tensorflow Version greather than 1.0.0')
+
+    # Init result var
+    accuracy = 0.0
+
+    # Compute number of batches
+    nb_batches = int(math.ceil(float(len(X_test)) / args.batch_size))
+    assert nb_batches * args.batch_size >= len(X_test)
+
+    X_cur = np.zeros((args.batch_size,) + X_test.shape[1:],
+                     dtype=X_test.dtype)
+    Y_cur = np.zeros((args.batch_size,) + Y_test.shape[1:],
+                     dtype=Y_test.dtype)
+
+    tfe = tf.contrib.eager
+    batch_x = tfe.Variable(X_test[0:args.batch_size], dtype=tf.float32)
+    batch_y = tfe.Variable(Y_test[0:args.batch_size], dtype=tf.float32)
+    for batch in range(nb_batches):
+        if batch % 100 == 0 and batch > 0:
+            _logger.debug("Batch " + str(batch))
+
+        # Must not use the `batch_indices` function here, because it
+        # repeats some examples.
+        # It's acceptable to repeat during training, but not eval.
+        start = batch * args.batch_size
+        end = min(len(X_test), start + args.batch_size)
+
+        # The last batch may be smaller than all others. This should not
+        # affect the accuarcy disproportionately.
+        cur_batch_size = end - start
+        X_cur[:cur_batch_size] = X_test[start:end]
+        Y_cur[:cur_batch_size] = Y_test[start:end]
+        tf.assign(batch_x, X_cur)
+        tf.assign(batch_y, Y_cur)
+        if attack is not None:
+            batch_adv_x = attack.generate(batch_x, **attack_args)
+            predictions = model(batch_adv_x)
+        else:
+            predictions = model(batch_x)
+        cur_corr_preds = tf.equal(tf.argmax(batch_y, axis=-1),
+                                  tf.argmax(predictions, axis=-1))
+
+        accuracy += cur_corr_preds.numpy()[:cur_batch_size].sum()
+
+    assert end >= len(X_test)
+
+    # Divide by number of examples to get final value
+    accuracy /= len(X_test)
+
+    return accuracy
+
+
+def tf_model_load(file_path=None):
+    """
+    :param file_path: path to the restored ckpt, if None is
+                      taken from FLAGS.train_dir and FLAGS.filename
+    :return:
+    """
+    assert file_path != None, 'pretrained model ckpt is not given.' 
+    saver = tf.train.Saver()
+    saver.restore(file_path)
+    return True
+
+
+def model_argmax(model, samples,):
+    """
+    Helper function that computes the current class prediction
+    :param samples: numpy array with input samples (dims must match x)
+    :return: the argmax output of predictions, i.e. the current predicted class
+    """
+    tfe = tf.contrib.eager
+    tf_samples = tfe.Variable(samples)
+    probabilities = model(tf_samples)
+
+    if samples.shape[0] == 1:
+        return tf.argmax(probabilities)
+    else:
+        return tf.argmax(probabilities, axis=1)

--- a/cleverhans/utils_tfe.py
+++ b/cleverhans/utils_tfe.py
@@ -20,9 +20,9 @@ _logger = create_logger("cleverhans.utils.tfe")
 
 
 def train(model, X_train=None, Y_train=None, save=False,
-                predictions_adv=None, evaluate=None,
-                args=None, rng=None, var_list=None,
-                attack=None, attack_args=None):
+          predictions_adv=None, evaluate=None,
+          args=None, rng=None, var_list=None,
+          attack=None, attack_args=None):
     """
     Train a TF Eager model
     :param model: instance of cleverhans model, takes in input batch,
@@ -47,8 +47,8 @@ def train(model, X_train=None, Y_train=None, save=False,
     """
     args = _ArgsWrapper(args or {})
     if ((attack is None) != (attack_args is None)):
-        error = "attack and attack_args must be passed together."
-        raise ValueError(error)
+        raise ValueError("attack and attack_args must be "
+                         "passed together.")
     if X_train is None or Y_train is None:
         raise ValueError("X_train argument and Y_train argument "
                          "must be supplied.")
@@ -143,8 +143,8 @@ def model_eval(model, X_test=None, Y_test=None, args=None,
     args = _ArgsWrapper(args or {})
 
     if ((attack is None) != (attack_args is None)):
-        error = "attack and attack_args must be passed together."
-        raise ValueError(error)
+        raise ValueError("attack and attack_args must be "
+                         "passed together.")
     assert args.batch_size, "Batch size was not given in args dict"
     if X_test is None or Y_test is None:
         raise ValueError("X_test argument and Y_test argument "
@@ -210,13 +210,13 @@ def tf_model_load(file_path=None):
                       taken from FLAGS.train_dir and FLAGS.filename
     :return:
     """
-    assert file_path != None, 'pretrained model ckpt is not given.' 
+    assert file_path is not None, "pretrained model ckpt is not given."
     saver = tf.train.Saver()
     saver.restore(file_path)
     return True
 
 
-def model_argmax(model, samples,):
+def model_argmax(model, samples):
     """
     Helper function that computes the current class prediction
     :param samples: numpy array with input samples (dims must match x)

--- a/cleverhans_tutorials/mnist_tutorial_tfe.py
+++ b/cleverhans_tutorials/mnist_tutorial_tfe.py
@@ -1,0 +1,253 @@
+"""
+This tutorial shows how to generate adversarial examples using FGSM
+and train a model using adversarial training with TensorFlow Eager.
+
+It is similar to mnist_tutorial_tf.py.
+mnist_tutorial_tf - dynaminc eager execution.
+mnist_tutorial_tf - graph based execution.
+The original paper can be found at:
+https://arxiv.org/abs/1412.6572
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import logging
+import sys
+import os
+import tensorflow as tf
+from tensorflow.python.platform import flags
+from distutils.version import LooseVersion
+
+try:
+    tf.enable_eager_execution()
+except AttributeError:
+    if LooseVersion(tf.__version__) < LooseVersion('1.8.0'):
+        error = ('For eager execution',
+                 'use Tensorflow version greather than 1.8.0.')
+        print(error)
+        exit(1)
+
+from cleverhans.utils_mnist import data_mnist
+from cleverhans.utils import AccuracyReport, set_log_level
+from cleverhans.utils_tfe import train, model_eval
+from cleverhans.attacks_tfe import FastGradientMethodTFE
+from cleverhans_tutorials.tutorial_models_tfe import ModelBasicCNNTFE
+
+if tf.executing_eagerly() is True:
+    print('TF Eager Activated.')
+else:
+    error = 'Error Enabling Eager Execution.'
+    raise Exception(error)
+tfe = tf.contrib.eager
+
+FLAGS = flags.FLAGS
+
+
+# Keeps track of implemented attacks.
+# Maps attack string taken from bash to attack class
+# -- 'fgsm' : FastGradientMethod
+
+ListOfAttacks = {
+                 'fgsm': FastGradientMethodTFE
+                }
+
+
+def attack_selection(attack_string):
+
+    """
+    Selects the Attack Class using string input.
+    :param attack_string: adversarial attack name in string format
+    :return: attack class defined in cleverhans.attacks_eager
+    """
+
+    # List of Implemented attacks
+    attacks_list = ListOfAttacks.keys()
+
+    # Checking for  requested attack in list of available attacks.
+    if attack_string is None:
+        error = 'Attack type is not specified, list of available attacks\t'
+        error += attacks_list
+        raise AttributeError(error)
+    if attack_string not in attacks_list:
+        error = 'Attack not available, list of available attacks\t'
+        error += attacks_list
+        raise AttributeError(error)
+    # Mapping attack from string to class.
+    attack_class = ListOfAttacks[attack_string]
+    return attack_class
+
+
+def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
+                   test_end=10000, nb_epochs=6, batch_size=128,
+                   learning_rate=0.001,
+                   clean_train=True,
+                   testing=False,
+                   backprop_through_attack=False,
+                   nb_filters=64, num_threads=None,
+                   attack_string=None):
+    """
+    MNIST cleverhans tutorial
+    :param train_start: index of first training set example.
+    :param train_end: index of last training set example.
+    :param test_start: index of first test set example.
+    :param test_end: index of last test set example.
+    :param nb_epochs: number of epochs to train model.
+    :param batch_size: size of training batches.
+    :param learning_rate: learning rate for training.
+    :param clean_train: perform normal training on clean examples only
+                        before performing adversarial training.
+    :param testing: if true, complete an AccuracyReport for unit tests
+                    to verify that performance is adequate.
+    :param backprop_through_attack: If True, backprop through adversarial
+                                    example construction process during
+                                    adversarial training.
+    :param nb_filters: number of filters in the CNN used for training.
+    :param num_threads: number of threads used for running the process.
+    :param attack_string: attack name for crafting adversarial attacks and
+                            adversarial training, in string format.
+    :return: an AccuracyReport object
+    """
+
+    # Object used to keep track of (and return) key accuracies
+    report = AccuracyReport()
+
+    # Set TF random seed to improve reproducibility
+    tf.set_random_seed(1234)
+
+    # Set logging level to see debug information
+    set_log_level(logging.DEBUG)
+
+    # Get MNIST test data
+    X_train, Y_train, X_test, Y_test = data_mnist(train_start=train_start,
+                                                  train_end=train_end,
+                                                  test_start=test_start,
+                                                  test_end=test_end)
+
+    # Use label smoothing
+    assert Y_train.shape[1] == 10
+    label_smooth = .1
+    Y_train = Y_train.clip(label_smooth / 9., 1. - label_smooth)
+
+    # Train an MNIST model
+    model_path = "models/mnist"
+    train_params = {
+        'nb_epochs': nb_epochs,
+        'batch_size': batch_size,
+        'learning_rate': learning_rate
+    }
+
+    # Initialize the attack object
+    attack_class = attack_selection(attack_string)
+    attack_params = {
+        'eps': 0.3, 'clip_min': 0.,
+        'clip_max': 1.}
+
+    rng = np.random.RandomState([2018, 6, 18])
+    if clean_train:
+        model = ModelBasicCNNTFE(nb_filters=nb_filters)
+
+        def evaluate_clean():
+            """Evaluate the accuracy of the MNIST model on legitimate test
+            examples
+            """
+            eval_params = {'batch_size': batch_size}
+            acc = model_eval(model, X_test, Y_test, args=eval_params)
+            report.clean_train_clean_eval = acc
+            assert X_test.shape[0] == test_end - test_start, X_test.shape
+            print('Test accuracy on legitimate examples: %0.4f' % acc)
+
+        train(model, X_train, Y_train, evaluate=evaluate_clean,
+                    args=train_params, rng=rng, var_list=model.get_params())
+
+        if testing:
+            # Calculate training error
+            eval_params = {'batch_size': batch_size}
+            acc = model_eval(model, X_train, Y_train, args=eval_params)
+            report.train_clean_train_clean_eval = acc
+
+        # Evaluate the accuracy of the MNIST model on adversarial examples
+        eval_par = {'batch_size': batch_size}
+        attack = attack_class(model)
+        acc = model_eval(
+            model, X_test, Y_test, args=eval_par,
+            attack=attack, attack_args=attack_params)
+        print('Test accuracy on adversarial examples: %0.4f\n' % acc)
+        report.clean_train_adv_eval = acc
+
+        # Calculate training error
+        if testing:
+            eval_par = {'batch_size': batch_size}
+            acc = model_eval(
+                model, X_train, Y_train, args=eval_par,
+                attack=attack, attack_args=attack_params)
+            print('Train accuracy on adversarial examples: %0.4f\n' % acc)
+            report.train_clean_train_adv_eval = acc
+
+        # Clear the previous Variables
+        for var in model.get_params():
+            var = None
+        attack = None
+        print("Repeating the process, using adversarial training")
+
+    model_adv_train = ModelBasicCNNTFE(nb_filters=nb_filters)
+    attack = attack_class(model_adv_train)
+
+    def evaluate_adv():
+        # Accuracy of adversarially trained model on legitimate test inputs
+        eval_params = {'batch_size': batch_size}
+        accuracy = model_eval(
+            model_adv_train, X_test, Y_test,
+            args=eval_params)
+        print('Test accuracy on legitimate examples: %0.4f' % accuracy)
+        report.adv_train_clean_eval = accuracy
+        # Accuracy of the adversarially trained model on adversarial examples
+        accuracy = model_eval(
+            model_adv_train, X_test, Y_test,
+            args=eval_params, attack=attack,
+            attack_args=attack_params)
+        print('Test accuracy on adversarial examples: %0.4f' % accuracy)
+        report.adv_train_adv_eval = accuracy
+
+    # Perform and evaluate adversarial training
+    train(model_adv_train, X_train, Y_train, evaluate=evaluate_adv,
+                args=train_params, rng=rng,
+                var_list=model_adv_train.get_params(),
+                attack=attack, attack_args=attack_params)
+
+    # Calculate training errors
+    if testing:
+        eval_params = {'batch_size': batch_size}
+        accuracy = model_eval(
+            model_adv_train, X_train, Y_train, args=eval_params,
+            attack=None, attack_args=None)
+        report.train_adv_train_clean_eval = accuracy
+        accuracy = model_eval(
+            model_adv_train, X_train, Y_train, args=eval_params,
+            attack=attack, attack_args=attack_params)
+        report.train_adv_train_adv_eval = accuracy
+    return report
+
+
+def main(argv=None):
+    mnist_tutorial(
+        nb_epochs=FLAGS.nb_epochs, batch_size=FLAGS.batch_size,
+        learning_rate=FLAGS.learning_rate, clean_train=FLAGS.clean_train,
+        backprop_through_attack=FLAGS.backprop_through_attack,
+        nb_filters=FLAGS.nb_filters, attack_string=FLAGS.attack)
+
+
+if __name__ == '__main__':
+    flags.DEFINE_integer('nb_filters', 64, 'Model size multiplier')
+    flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
+    flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
+    flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
+    flags.DEFINE_bool('clean_train', False, 'Train on clean examples')
+    flags.DEFINE_bool('backprop_through_attack', False,
+                      ('If True, backprop through adversarial example '
+                       'construction process during adversarial training'))
+    flags.DEFINE_string('attack', 'fgsm',
+                        'Adversarial attack crafted and used for training')
+    tf.app.run()

--- a/cleverhans_tutorials/mnist_tutorial_tfe.py
+++ b/cleverhans_tutorials/mnist_tutorial_tfe.py
@@ -49,8 +49,8 @@ FLAGS = flags.FLAGS
 # -- 'fgsm' : FastGradientMethod
 
 AVAILABLE_ATTACKS = {
-                 'fgsm': FastGradientMethodTFE
-                }
+                     'fgsm': FastGradientMethodTFE
+                    }
 
 
 def attack_selection(attack_string):

--- a/cleverhans_tutorials/mnist_tutorial_tfe.py
+++ b/cleverhans_tutorials/mnist_tutorial_tfe.py
@@ -25,9 +25,8 @@ try:
     tf.enable_eager_execution()
 except AttributeError:
     if LooseVersion(tf.__version__) < LooseVersion('1.8.0'):
-        error = ('For eager execution',
-                 'use Tensorflow version greather than 1.8.0.')
-        print(error)
+        print("For eager execution"
+              "use Tensorflow version greather than 1.8.0.")
         exit(1)
 
 from cleverhans.utils_mnist import data_mnist
@@ -39,8 +38,7 @@ from cleverhans_tutorials.tutorial_models_tfe import ModelBasicCNNTFE
 if tf.executing_eagerly() is True:
     print('TF Eager Activated.')
 else:
-    error = 'Error Enabling Eager Execution.'
-    raise Exception(error)
+    raise Exception("Error Enabling Eager Execution.")
 tfe = tf.contrib.eager
 
 FLAGS = flags.FLAGS
@@ -50,7 +48,7 @@ FLAGS = flags.FLAGS
 # Maps attack string taken from bash to attack class
 # -- 'fgsm' : FastGradientMethod
 
-ListOfAttacks = {
+AVAILABLE_ATTACKS = {
                  'fgsm': FastGradientMethodTFE
                 }
 
@@ -64,19 +62,17 @@ def attack_selection(attack_string):
     """
 
     # List of Implemented attacks
-    attacks_list = ListOfAttacks.keys()
+    attacks_list = AVAILABLE_ATTACKS.keys()
 
     # Checking for  requested attack in list of available attacks.
     if attack_string is None:
-        error = 'Attack type is not specified, list of available attacks\t'
-        error += attacks_list
-        raise AttributeError(error)
+        raise AttributeError("Attack type is not specified, "
+                             "list of available attacks\t".join(attacks_list))
     if attack_string not in attacks_list:
-        error = 'Attack not available, list of available attacks\t'
-        error += attacks_list
-        raise AttributeError(error)
+        raise AttributeError("Attack not available "
+                             "list of available attacks\t".join(attacks_list))
     # Mapping attack from string to class.
-    attack_class = ListOfAttacks[attack_string]
+    attack_class = AVAILABLE_ATTACKS[attack_string]
     return attack_class
 
 
@@ -141,9 +137,8 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
     # Initialize the attack object
     attack_class = attack_selection(attack_string)
-    attack_params = {
-        'eps': 0.3, 'clip_min': 0.,
-        'clip_max': 1.}
+    attack_params = {'eps': 0.3, 'clip_min': 0.,
+                     'clip_max': 1.}
 
     rng = np.random.RandomState([2018, 6, 18])
     if clean_train:
@@ -160,7 +155,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
             print('Test accuracy on legitimate examples: %0.4f' % acc)
 
         train(model, X_train, Y_train, evaluate=evaluate_clean,
-                    args=train_params, rng=rng, var_list=model.get_params())
+              args=train_params, rng=rng, var_list=model.get_params())
 
         if testing:
             # Calculate training error
@@ -213,9 +208,9 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
     # Perform and evaluate adversarial training
     train(model_adv_train, X_train, Y_train, evaluate=evaluate_adv,
-                args=train_params, rng=rng,
-                var_list=model_adv_train.get_params(),
-                attack=attack, attack_args=attack_params)
+          args=train_params, rng=rng,
+          var_list=model_adv_train.get_params(),
+          attack=attack, attack_args=attack_params)
 
     # Calculate training errors
     if testing:
@@ -244,7 +239,7 @@ if __name__ == '__main__':
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
     flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
-    flags.DEFINE_bool('clean_train', False, 'Train on clean examples')
+    flags.DEFINE_bool('clean_train', True, 'Train on clean examples')
     flags.DEFINE_bool('backprop_through_attack', False,
                       ('If True, backprop through adversarial example '
                        'construction process during adversarial training'))

--- a/cleverhans_tutorials/tutorial_models_tfe.py
+++ b/cleverhans_tutorials/tutorial_models_tfe.py
@@ -1,5 +1,5 @@
 """
-A TensorFlow Eager implementation of a neural network. 
+A TensorFlow Eager implementation of a neural network.
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -8,17 +8,16 @@ from __future__ import unicode_literals
 
 import tensorflow as tf
 from cleverhans.model import Model
-#tf.enable_eager_execution()
 
 
 class ModelBasicCNNTFE(Model):
     """
-    Basic CNN model for tensorflow eager execution. 
+    Basic CNN model for tensorflow eager execution.
     """
     def __init__(self, nb_classes=10,
-                 nb_filters=64, dummy_input=tf.zeros((32,28,28,1))):
+                 nb_filters=64, dummy_input=tf.zeros((32, 28, 28, 1))):
         Model.__init__(self, nb_classes=nb_classes)
-        
+
         # Parametes
         # number of filters, number of classes.
         self.nb_filters = nb_filters
@@ -26,22 +25,27 @@ class ModelBasicCNNTFE(Model):
 
         # Lists for layers attributes.
         # layer names , layers, layer activations
-        self.layer_names = ['input', 'conv_1', 'conv_2', 'conv_3', 'flatten', 'logits']
+        self.layer_names = ['input', 'conv_1', 'conv_2', 'conv_3', 'flatten',
+                            'logits']
         self.layers = {}
-        self.layer_acts ={}
+        self.layer_acts = {}
 
         # layer definitions
         self.layers['conv_1'] = tf.layers.Conv2D(filters=self.nb_filters,
                                                  kernel_size=8, strides=2,
-                                                 padding='same', activation=tf.nn.relu)
+                                                 padding='same',
+                                                 activation=tf.nn.relu)
         self.layers['conv_2'] = tf.layers.Conv2D(filters=self.nb_filters * 2,
                                                  kernel_size=6, strides=2,
-                                                 padding='valid', activation=tf.nn.relu)
+                                                 padding='valid',
+                                                 activation=tf.nn.relu)
         self.layers['conv_3'] = tf.layers.Conv2D(filters=self.nb_filters * 2,
                                                  kernel_size=5, strides=1,
-                                                 padding='valid', activation=tf.nn.relu)
+                                                 padding='valid',
+                                                 activation=tf.nn.relu)
         self.layers['flatten'] = tf.layers.Flatten()
-        self.layers['logits'] = tf.layers.Dense(self.nb_classes, activation=None)
+        self.layers['logits'] = tf.layers.Dense(self.nb_classes,
+                                                activation=None)
 
         # Dummy fprop to activate the network.
         output = self.fprop(dummy_input)
@@ -52,17 +56,19 @@ class ModelBasicCNNTFE(Model):
         :return: dictionary with layer names mapping to activation values.
         """
 
-        # Feed forward through the network layers 
+        # Feed forward through the network layers
         for layer_name in self.layer_names:
             if layer_name == 'input':
                 prev_layer_act = x
                 continue
             else:
-                self.layer_acts[layer_name] = self.layers[layer_name](prev_layer_act)
+                self.layer_acts[layer_name] = self.layers[layer_name](
+                                                                prev_layer_act)
                 prev_layer_act = self.layer_acts[layer_name]
-        
+
         # Adding softmax values to list of activations.
-        self.layer_acts['probs'] = tf.nn.softmax(logits=self.layer_acts['logits'])
+        self.layer_acts['probs'] = tf.nn.softmax(
+                                        logits=self.layer_acts['logits'])
         return self.layer_acts
 
     def get_layer_params(self, layer_name):
@@ -114,16 +120,3 @@ class ModelBasicCNNTFE(Model):
         """
         logits = self.fprop(x)['logits']
         return logits
-
-
-if __name__ == "__main__":
-    model = ModelBasicCNNTFE()
-    ln = model.get_layer_names()
-    p = model.get_params()
-    inp = tf.zeros((64,32,32, 1))
-    fp = model.fprop(inp)
-    fl = model.get_logits(inp)
-    fpr = model.get_probs(inp)
-    for key in fp:
-        print(key, fp[key].shape)
-    print(fl.dtype)

--- a/cleverhans_tutorials/tutorial_models_tfe.py
+++ b/cleverhans_tutorials/tutorial_models_tfe.py
@@ -1,0 +1,129 @@
+"""
+A TensorFlow Eager implementation of a neural network. 
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import tensorflow as tf
+from cleverhans.model import Model
+#tf.enable_eager_execution()
+
+
+class ModelBasicCNNTFE(Model):
+    """
+    Basic CNN model for tensorflow eager execution. 
+    """
+    def __init__(self, nb_classes=10,
+                 nb_filters=64, dummy_input=tf.zeros((32,28,28,1))):
+        Model.__init__(self, nb_classes=nb_classes)
+        
+        # Parametes
+        # number of filters, number of classes.
+        self.nb_filters = nb_filters
+        self.nb_classes = nb_classes
+
+        # Lists for layers attributes.
+        # layer names , layers, layer activations
+        self.layer_names = ['input', 'conv_1', 'conv_2', 'conv_3', 'flatten', 'logits']
+        self.layers = {}
+        self.layer_acts ={}
+
+        # layer definitions
+        self.layers['conv_1'] = tf.layers.Conv2D(filters=self.nb_filters,
+                                                 kernel_size=8, strides=2,
+                                                 padding='same', activation=tf.nn.relu)
+        self.layers['conv_2'] = tf.layers.Conv2D(filters=self.nb_filters * 2,
+                                                 kernel_size=6, strides=2,
+                                                 padding='valid', activation=tf.nn.relu)
+        self.layers['conv_3'] = tf.layers.Conv2D(filters=self.nb_filters * 2,
+                                                 kernel_size=5, strides=1,
+                                                 padding='valid', activation=tf.nn.relu)
+        self.layers['flatten'] = tf.layers.Flatten()
+        self.layers['logits'] = tf.layers.Dense(self.nb_classes, activation=None)
+
+        # Dummy fprop to activate the network.
+        output = self.fprop(dummy_input)
+
+    def fprop(self, x):
+        """
+        Forward propagation throught the network
+        :return: dictionary with layer names mapping to activation values.
+        """
+
+        # Feed forward through the network layers 
+        for layer_name in self.layer_names:
+            if layer_name == 'input':
+                prev_layer_act = x
+                continue
+            else:
+                self.layer_acts[layer_name] = self.layers[layer_name](prev_layer_act)
+                prev_layer_act = self.layer_acts[layer_name]
+        
+        # Adding softmax values to list of activations.
+        self.layer_acts['probs'] = tf.nn.softmax(logits=self.layer_acts['logits'])
+        return self.layer_acts
+
+    def get_layer_params(self, layer_name):
+        """
+        Provides access to the parameters of the given layer.
+        Works arounds the non-availability of graph collections in
+                    eager mode.
+        :layer_name: name of the layer for which parameters are
+                    required, must be one of the string in the
+                    list layer_names
+        :return: list of parameters corresponding to the given
+                    layer.
+        """
+        assert layer_name in self.layer_names
+
+        out = []
+        layer = self.layers[layer_name]
+        layer_variables = layer.variables
+
+        # For each parameter in a layer.
+        for param in layer_variables:
+            if param not in out:
+                out.append(param)
+        return out
+
+    def get_params(self):
+        """
+        Provides access to the model's parameters.
+        Works arounds the non-availability of graph collections in
+                        eager mode.
+        :return: A list of all Variables defining the model parameters.
+        """
+        assert tf.executing_eagerly()
+        out = []
+
+        # Collecting params from each layer.
+        for layer_name in self.layers:
+            out += self.get_layer_params(layer_name)
+        return out
+
+    def get_layer_names(self):
+        """:return: the list of exposed layers for this model."""
+        return self.layer_names
+
+    def call(x):
+        """
+        :x: input to the network.
+        :return: logits from the network.
+        """
+        logits = self.fprop(x)['logits']
+        return logits
+
+
+if __name__ == "__main__":
+    model = ModelBasicCNNTFE()
+    ln = model.get_layer_names()
+    p = model.get_params()
+    inp = tf.zeros((64,32,32, 1))
+    fp = model.fprop(inp)
+    fl = model.get_logits(inp)
+    fpr = model.get_probs(inp)
+    for key in fp:
+        print(key, fp[key].shape)
+    print(fl.dtype)


### PR DESCRIPTION
For eager execution. 
1. A subclass of cleverhans.model.Model for tf.eager models is added. (cleverhans.model.Model_Eager), 
this uses only tf_eager without any keras dependencies.

2. New file attacks_eager is added, (existing attacks run through session using feed_dict making it too hard to adapt.), 
but structure of attacks.py is adapted to attacks_eager.py,  so objects of both attack classes can be replaced with out any difference.

3. tutorial to show the use tutorial_mnist_eager.py

4. unit tests for all the above.  