### PR TITLE
Generalizing the cleverhans_tutorial for non-MNIST dataset 

### DIFF
--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -76,7 +76,7 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
         'learning_rate': learning_rate
     }
     model_train(sess, x, y, predictions, X_train, Y_train,
-                args=train_params, rng=rng,, var_list=model.get_params())
+                args=train_params, rng=rng, var_list=model.get_params())
 
     # Print out the accuracy on legitimate data
     eval_params = {'batch_size': batch_size}

--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -76,7 +76,7 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
         'learning_rate': learning_rate
     }
     model_train(sess, x, y, predictions, X_train, Y_train,
-                args=train_params, rng=rng)
+                args=train_params, rng=rng,, var_list=model.get_params())
 
     # Print out the accuracy on legitimate data
     eval_params = {'batch_size': batch_size}
@@ -151,7 +151,8 @@ def train_sub(sess, x, y, bbox_preds, X_sub, Y_sub, nb_classes,
         with TemporaryLogLevel(logging.WARNING, "cleverhans.utils.tf"):
             model_train(sess, x, y, preds_sub, X_sub,
                         to_categorical(Y_sub, nb_classes),
-                        init_all=False, args=train_params, rng=rng)
+                        init_all=False, args=train_params, rng=rng,
+                        var_list=model_sub.get_params())
 
         # If we are not at last substitute training iteration, augment dataset
         if rho < data_aug - 1:

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -28,7 +28,7 @@ FLAGS = flags.FLAGS
 
 def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                       test_end=10000, viz_enabled=True, nb_epochs=6,
-                      batch_size=128, nb_classes=10, source_samples=10,
+                      batch_size=128, source_samples=10,
                       learning_rate=0.001, attack_iterations=100,
                       model_path=os.path.join("models", "mnist"),
                       targeted=True):
@@ -51,11 +51,6 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     # Object used to keep track of (and return) key accuracies
     report = AccuracyReport()
 
-    # MNIST-specific dimensions
-    img_rows = 28
-    img_cols = 28
-    channels = 1
-
     # Set TF random seed to improve reproducibility
     tf.set_random_seed(1234)
 
@@ -71,12 +66,20 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
-    # Define input TF placeholder
-    x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols, channels))
-    y = tf.placeholder(tf.float32, shape=(None, nb_classes))
+    # Use label smoothing
+    print(X_train.shape)
+    img_rows,img_cols,nchannels = X_train.shape[1:4]
+    nb_classes = Y_train.shape[1]
 
+    # Define input TF placeholder
+    x = tf.placeholder(tf.float32, shape=(None,img_rows,img_cols,nchannels))
+    y = tf.placeholder(tf.float32, shape=(None,nb_classes))
+    
+    nb_filters = 64
+    
     # Define TF model graph
-    model = make_basic_cnn()
+    model = make_basic_cnn(nb_filters, nb_classes,
+                   input_shape=(None, img_rows,img_cols,nchannels))
     preds = model(x)
     print("Defined TensorFlow model graph.")
 
@@ -104,7 +107,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     # Evaluate the accuracy of the MNIST model on legitimate test examples
     eval_params = {'batch_size': batch_size}
     accuracy = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
-    assert X_test.shape[0] == test_end - test_start, X_test.shape
+#    assert X_test.shape[0] == test_end - test_start, X_test.shape
     print('Test accuracy on legitimate test examples: {0}'.format(accuracy))
     report.clean_train_clean_eval = accuracy
 
@@ -126,7 +129,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     if targeted:
         if viz_enabled:
             # Initialize our array for grid visualization
-            grid_shape = (nb_classes, nb_classes, img_rows, img_cols, channels)
+            grid_shape = (nb_classes, nb_classes, img_rows, img_cols, nchannels)
             grid_viz_data = np.zeros(grid_shape, dtype='f')
 
             adv_inputs = np.array(
@@ -141,7 +144,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
         one_hot[np.arange(nb_classes), np.arange(nb_classes)] = 1
 
         adv_inputs = adv_inputs.reshape(
-            (source_samples * nb_classes, img_rows, img_cols, 1))
+            (source_samples * nb_classes, img_rows, img_cols, nchannels))
         adv_ys = np.array([one_hot] * source_samples,
                           dtype=np.float32).reshape((source_samples *
                                                      nb_classes, nb_classes))
@@ -149,7 +152,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     else:
         if viz_enabled:
             # Initialize our array for grid visualization
-            grid_shape = (nb_classes, 2, img_rows, img_cols, channels)
+            grid_shape = (nb_classes, 2, img_rows, img_cols, nchannels)
             grid_viz_data = np.zeros(grid_shape, dtype='f')
 
             adv_inputs = X_test[idxs]
@@ -221,7 +224,6 @@ def main(argv=None):
     mnist_tutorial_cw(viz_enabled=FLAGS.viz_enabled,
                       nb_epochs=FLAGS.nb_epochs,
                       batch_size=FLAGS.batch_size,
-                      nb_classes=FLAGS.nb_classes,
                       source_samples=FLAGS.source_samples,
                       learning_rate=FLAGS.learning_rate,
                       attack_iterations=FLAGS.attack_iterations,
@@ -233,7 +235,6 @@ if __name__ == '__main__':
     flags.DEFINE_boolean('viz_enabled', True, 'Visualize adversarial ex.')
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
-    flags.DEFINE_integer('nb_classes', 10, 'Number of output classes')
     flags.DEFINE_integer('source_samples', 10, 'Nb of test inputs to attack')
     flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
     flags.DEFINE_string('model_path', os.path.join("models", "mnist"),

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -28,7 +28,7 @@ FLAGS = flags.FLAGS
 
 def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
                         test_end=10000, viz_enabled=True, nb_epochs=6,
-                        batch_size=128, nb_classes=10, source_samples=10,
+                        batch_size=128, source_samples=10,
                         learning_rate=0.001):
     """
     MNIST tutorial for the Jacobian-based saliency map approach (JSMA)
@@ -47,10 +47,6 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     # Object used to keep track of (and return) key accuracies
     report = AccuracyReport()
 
-    # MNIST-specific dimensions
-    img_rows = 28
-    img_cols = 28
-    channels = 1
 
     # Set TF random seed to improve reproducibility
     tf.set_random_seed(1234)
@@ -67,12 +63,18 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
-    # Define input TF placeholder
-    x = tf.placeholder(tf.float32, shape=(None, 28, 28, 1))
-    y = tf.placeholder(tf.float32, shape=(None, 10))
+    print(X_train.shape)
+    img_rows,img_cols,nchannels = X_train.shape[1:4]
+    nb_classes = Y_train.shape[1]
 
+    # Define input TF placeholder
+    x = tf.placeholder(tf.float32, shape=(None,img_rows,img_cols,nchannels))
+    y = tf.placeholder(tf.float32, shape=(None,nb_classes))
+    
+    nb_filters = 64
     # Define TF model graph
-    model = make_basic_cnn()
+    model = make_basic_cnn(nb_filters, nb_classes,
+                   input_shape=(None, img_rows,img_cols,nchannels))
     preds = model(x)
     print("Defined TensorFlow model graph.")
 
@@ -94,7 +96,7 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     # Evaluate the accuracy of the MNIST model on legitimate test examples
     eval_params = {'batch_size': batch_size}
     accuracy = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
-    assert X_test.shape[0] == test_end - test_start, X_test.shape
+#    assert X_test.shape[0] == test_end - test_start, X_test.shape
     print('Test accuracy on legitimate test examples: {0}'.format(accuracy))
     report.clean_train_clean_eval = accuracy
 
@@ -111,7 +113,7 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     perturbations = np.zeros((nb_classes, source_samples), dtype='f')
 
     # Initialize our array for grid visualization
-    grid_shape = (nb_classes, nb_classes, img_rows, img_cols, channels)
+    grid_shape = (nb_classes, nb_classes, img_rows, img_cols, nchannels)
     grid_viz_data = np.zeros(grid_shape, dtype='f')
 
     # Instantiate a SaliencyMapMethod attack object
@@ -134,7 +136,7 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
 
         # For the grid visualization, keep original images along the diagonal
         grid_viz_data[current_class, current_class, :, :, :] = np.reshape(
-            sample, (img_rows, img_cols, channels))
+            sample, (img_rows, img_cols, nchannels))
 
         # Loop over all target classes
         for target in target_classes:
@@ -158,12 +160,12 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
             # Display the original and adversarial images side-by-side
             if viz_enabled:
                 figure = pair_visual(
-                    np.reshape(sample, (img_rows, img_cols, channels)),
-                    np.reshape(adv_x, (img_rows, img_cols, channels)), figure)
+                    np.reshape(sample, (img_rows, img_cols, nchannels)),
+                    np.reshape(adv_x, (img_rows, img_cols, nchannels)), figure)
 
             # Add our adversarial example to our grid data
             grid_viz_data[target, current_class, :, :, :] = np.reshape(
-                adv_x, (img_rows, img_cols, channels))
+                adv_x, (img_rows, img_cols, nchannels))
 
             # Update the arrays for later analysis
             results[target, sample_ind] = res
@@ -202,7 +204,6 @@ def main(argv=None):
     mnist_tutorial_jsma(viz_enabled=FLAGS.viz_enabled,
                         nb_epochs=FLAGS.nb_epochs,
                         batch_size=FLAGS.batch_size,
-                        nb_classes=FLAGS.nb_classes,
                         source_samples=FLAGS.source_samples,
                         learning_rate=FLAGS.learning_rate)
 
@@ -211,7 +212,6 @@ if __name__ == '__main__':
     flags.DEFINE_boolean('viz_enabled', True, 'Visualize adversarial ex.')
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
-    flags.DEFINE_integer('nb_classes', 10, 'Number of output classes')
     flags.DEFINE_integer('source_samples', 10, 'Nb of test inputs to attack')
     flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
 

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -16,6 +16,7 @@ import keras
 from keras import backend
 import tensorflow as tf
 from tensorflow.python.platform import flags
+import os
 
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils_tf import model_train, model_eval
@@ -29,9 +30,9 @@ FLAGS = flags.FLAGS
 
 def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                    test_end=10000, nb_epochs=6, batch_size=128,
-                   learning_rate=0.001, train_dir="/tmp",
+                   learning_rate=0.001, train_dir="train_dir",
                    filename="mnist.ckpt", load_model=False,
-                   testing=False):
+                   testing=False,label_smoothing=True):
     """
     MNIST CleverHans tutorial
     :param train_start: index of first training set example
@@ -75,16 +76,21 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                                                   test_end=test_end)
 
     # Use label smoothing
-    assert Y_train.shape[1] == 10
-    label_smooth = .1
-    Y_train = Y_train.clip(label_smooth / 9., 1. - label_smooth)
+    print(X_train.shape)
+    img_rows,img_cols,nchannels = X_train.shape[1:4]
+    nb_classes = Y_train.shape[1]
+
+    if label_smoothing:
+        label_smooth = .1
+        Y_train = Y_train.clip(label_smooth / (nb_classes-1) , 1. - label_smooth)
 
     # Define input TF placeholder
-    x = tf.placeholder(tf.float32, shape=(None, 28, 28, 1))
-    y = tf.placeholder(tf.float32, shape=(None, 10))
+    x = tf.placeholder(tf.float32, shape=(None,img_rows,img_cols,nchannels))
+    y = tf.placeholder(tf.float32, shape=(None,nb_classes))
 
     # Define TF model graph
-    model = cnn_model()
+    model = cnn_model(img_rows=img_rows, img_cols=img_cols,
+              channels=nchannels, nb_filters=64, nb_classes=nb_classes)
     preds = model(x)
     print("Defined TensorFlow model graph.")
 
@@ -93,7 +99,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
         eval_params = {'batch_size': batch_size}
         acc = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
         report.clean_train_clean_eval = acc
-        assert X_test.shape[0] == test_end - test_start, X_test.shape
+#        assert X_test.shape[0] == test_end - test_start, X_test.shape
         print('Test accuracy on legitimate examples: %0.4f' % acc)
 
     # Train an MNIST model
@@ -104,10 +110,14 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
         'train_dir': train_dir,
         'filename': filename
     }
-    ckpt = tf.train.get_checkpoint_state(train_dir)
-    ckpt_path = False if ckpt is None else ckpt.model_checkpoint_path
 
     rng = np.random.RandomState([2017, 8, 30])
+    if not os.path.exists(train_dir):
+        os.mkdir( train_dir)
+
+    ckpt = tf.train.get_checkpoint_state(train_dir)
+    ckpt_path = False if ckpt is None else ckpt.model_checkpoint_path
+        
     if load_model and ckpt_path:
         saver = tf.train.Saver()
         saver.restore(sess, ckpt_path)
@@ -150,7 +160,8 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
     print("Repeating the process, using adversarial training")
     # Redefine TF model graph
-    model_2 = cnn_model()
+    model_2 = cnn_model(img_rows=img_rows, img_cols=img_cols,
+              channels=nchannels, nb_filters=64, nb_classes=nb_classes)
     preds_2 = model_2(x)
     wrap_2 = KerasModelWrapper(model_2)
     fgsm2 = FastGradientMethod(wrap_2, sess=sess)
@@ -201,7 +212,7 @@ if __name__ == '__main__':
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
     flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
-    flags.DEFINE_string('train_dir', '/tmp', 'Directory where to save model.')
+    flags.DEFINE_string('train_dir', './train_dir', 'Directory where to save model.')
     flags.DEFINE_string('filename', 'mnist.ckpt', 'Checkpoint filename.')
     flags.DEFINE_boolean('load_model', True, 'Load saved model or train.')
     tf.app.run()

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -116,7 +116,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 #            assert X_test.shape[0] == test_end - test_start, X_test.shape
             print('Test accuracy on legitimate examples: %0.4f' % acc)
         model_train(sess, x, y, preds, X_train, Y_train, evaluate=evaluate,
-                    args=train_params, rng=rng)
+                    args=train_params, rng=rng, var_list=model.get_params())
 
         # Calculate training error
         if testing:
@@ -178,7 +178,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     # Perform and evaluate adversarial training
     model_train(sess, x, y, preds_2, X_train, Y_train,
                 predictions_adv=preds_2_adv, evaluate=evaluate_2,
-                args=train_params, rng=rng)
+                args=train_params, rng=rng,var_list=model_2.get_params())
 
     # Calculate training errors
     if testing:

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -178,7 +178,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     # Perform and evaluate adversarial training
     model_train(sess, x, y, preds_2, X_train, Y_train,
                 predictions_adv=preds_2_adv, evaluate=evaluate_2,
-                args=train_params, rng=rng,var_list=model_2.get_params())
+                args=train_params, rng=rng, var_list=model_2.get_params())
 
     # Calculate training errors
     if testing:

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -33,7 +33,8 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                    clean_train=True,
                    testing=False,
                    backprop_through_attack=False,
-                   nb_filters=64, num_threads=None):
+                   nb_filters=64, num_threads=None,
+                   label_smoothing = True):
     """
     MNIST cleverhans tutorial
     :param train_start: index of first training set example
@@ -75,15 +76,18 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                                                   train_end=train_end,
                                                   test_start=test_start,
                                                   test_end=test_end)
-
     # Use label smoothing
-    assert Y_train.shape[1] == 10
-    label_smooth = .1
-    Y_train = Y_train.clip(label_smooth / 9., 1. - label_smooth)
+    print(X_train.shape)
+    img_rows,img_cols,nchannels = X_train.shape[1:4]
+    nb_classes = Y_train.shape[1]
+
+    if label_smoothing:
+        label_smooth = .1
+        Y_train = Y_train.clip(label_smooth / (nb_classes-1) , 1. - label_smooth)
 
     # Define input TF placeholder
-    x = tf.placeholder(tf.float32, shape=(None, 28, 28, 1))
-    y = tf.placeholder(tf.float32, shape=(None, 10))
+    x = tf.placeholder(tf.float32, shape=(None,img_rows,img_cols,nchannels))
+    y = tf.placeholder(tf.float32, shape=(None,nb_classes))
 
     model_path = "models/mnist"
     # Train an MNIST model
@@ -98,7 +102,8 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     rng = np.random.RandomState([2017, 8, 30])
 
     if clean_train:
-        model = make_basic_cnn(nb_filters=nb_filters)
+        model = make_basic_cnn(nb_filters, nb_classes,
+                   input_shape=(None, img_rows,img_cols,nchannels))
         preds = model.get_probs(x)
 
         def evaluate():
@@ -108,10 +113,10 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
             acc = model_eval(
                 sess, x, y, preds, X_test, Y_test, args=eval_params)
             report.clean_train_clean_eval = acc
-            assert X_test.shape[0] == test_end - test_start, X_test.shape
+#            assert X_test.shape[0] == test_end - test_start, X_test.shape
             print('Test accuracy on legitimate examples: %0.4f' % acc)
         model_train(sess, x, y, preds, X_train, Y_train, evaluate=evaluate,
-                    args=train_params, rng=rng, var_list=model.get_params())
+                    args=train_params, rng=rng)
 
         # Calculate training error
         if testing:
@@ -141,7 +146,8 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
         print("Repeating the process, using adversarial training")
     # Redefine TF model graph
-    model_2 = make_basic_cnn(nb_filters=nb_filters)
+    model_2 = make_basic_cnn(nb_filters, nb_classes,
+                   input_shape=(None, img_rows,img_cols,nchannels))
     preds_2 = model_2(x)
     fgsm2 = FastGradientMethod(model_2, sess=sess)
     adv_x_2 = fgsm2.generate(x, **fgsm_params)
@@ -172,7 +178,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     # Perform and evaluate adversarial training
     model_train(sess, x, y, preds_2, X_train, Y_train,
                 predictions_adv=preds_2_adv, evaluate=evaluate_2,
-                args=train_params, rng=rng, var_list=model_2.get_params())
+                args=train_params, rng=rng)
 
     # Calculate training errors
     if testing:


### PR DESCRIPTION
The cleverhans_tutorial has been written only for MNIST with extensive hard coding of data-set parameters(like image width/height/channels. I have modified the code to handle other data-sets. The user need to only modify utils_mnist.py for his dataset and rest of the code will work out of box. Also I made sure the tutorials work for all image-size & channels. Image parameter are obtained from the X_train variable loaded by utils_mnist.py