### PR TITLE
Fixing the tutorial for non-MNIST datasets

### DIFF
--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -221,8 +221,8 @@ def mnist_blackbox(train_start=0, train_end=60000, test_start=0,
     y_test = y_test[holdout:]
 
     # Obtain Image parameters
-    img_rows, img_cols, nchannels = X_train.shape[1:4]
-    nb_classes = Y_train.shape[1]
+    img_rows, img_cols, nchannels = x_train.shape[1:4]
+    nb_classes = y_train.shape[1]
 
     # Define input TF placeholder
     x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols,

--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -44,7 +44,7 @@ def setup_tutorial():
 
 def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
               nb_epochs, batch_size, learning_rate,
-              rng):
+              rng, nb_classes=10, img_rows=28, img_cols=28, nchannels=1):
     """
     Define and train a model that simulates the "remote"
     black-box oracle described in the original paper.
@@ -63,7 +63,10 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
     """
 
     # Define TF model graph (for the black-box model)
-    model = make_basic_cnn()
+    nb_filters = 64
+    model = make_basic_cnn(nb_filters, nb_classes,
+                           input_shape=(None, img_rows, img_cols,
+                                        nchannels))
     predictions = model(x)
     print("Defined TensorFlow model graph.")
 
@@ -86,7 +89,7 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
     return model, predictions, accuracy
 
 
-def substitute_model(img_rows=28, img_cols=28, nb_classes=10):
+def substitute_model(img_rows=28, img_cols=28, nb_classes=10, nchannels=1):
     """
     Defines the model architecture to be used by the substitute. Use
     the example model interface.
@@ -95,7 +98,7 @@ def substitute_model(img_rows=28, img_cols=28, nb_classes=10):
     :param nb_classes: number of classes in output
     :return: tensorflow model
     """
-    input_shape = (None, img_rows, img_cols, 1)
+    input_shape = (None, img_rows, img_cols, nchannels)
 
     # Define a fully connected model (it's different than the black-box)
     layers = [Flatten(),
@@ -111,7 +114,7 @@ def substitute_model(img_rows=28, img_cols=28, nb_classes=10):
 
 def train_sub(sess, x, y, bbox_preds, X_sub, Y_sub, nb_classes,
               nb_epochs_s, batch_size, learning_rate, data_aug, lmbda,
-              rng):
+              rng, img_rows=28, img_cols=28, nchannels=1):
     """
     This function creates the substitute by alternatively
     augmenting the training data and training the substitute.
@@ -131,7 +134,7 @@ def train_sub(sess, x, y, bbox_preds, X_sub, Y_sub, nb_classes,
     :return:
     """
     # Define TF model graph (for the black-box model)
-    model_sub = substitute_model()
+    model_sub = substitute_model(img_rows, img_cols, nb_classes, nchannels)
     preds_sub = model_sub(x)
     print("Defined TensorFlow model graph for the substitute.")
 
@@ -209,7 +212,6 @@ def mnist_blackbox(train_start=0, train_end=60000, test_start=0,
                                                   train_end=train_end,
                                                   test_start=test_start,
                                                   test_end=test_end)
-
     # Initialize substitute training set reserved for adversary
     X_sub = X_test[:holdout]
     Y_sub = np.argmax(Y_test[:holdout], axis=1)
@@ -218,9 +220,14 @@ def mnist_blackbox(train_start=0, train_end=60000, test_start=0,
     X_test = X_test[holdout:]
     Y_test = Y_test[holdout:]
 
-    # Define input and output TF placeholders
-    x = tf.placeholder(tf.float32, shape=(None, 28, 28, 1))
-    y = tf.placeholder(tf.float32, shape=(None, 10))
+    # Obtain Image parameters
+    img_rows, img_cols, nchannels = X_train.shape[1:4]
+    nb_classes = Y_train.shape[1]
+
+    # Define input TF placeholder
+    x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols,
+                                          nchannels))
+    y = tf.placeholder(tf.float32, shape=(None,     nb_classes))
 
     # Seed random number generator so tutorial is reproducible
     rng = np.random.RandomState([2017, 8, 30])
@@ -230,14 +237,15 @@ def mnist_blackbox(train_start=0, train_end=60000, test_start=0,
     print("Preparing the black-box model.")
     prep_bbox_out = prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
                               nb_epochs, batch_size, learning_rate,
-                              rng=rng)
+                              rng, nb_classes, img_rows, img_cols, nchannels)
     model, bbox_preds, accuracies['bbox'] = prep_bbox_out
 
     # Train substitute using method from https://arxiv.org/abs/1602.02697
     print("Training the substitute model.")
     train_sub_out = train_sub(sess, x, y, bbox_preds, X_sub, Y_sub,
                               nb_classes, nb_epochs_s, batch_size,
-                              learning_rate, data_aug, lmbda, rng=rng)
+                              learning_rate, data_aug, lmbda, rng,
+                              img_rows, img_cols, nchannels)
     model_sub, preds_sub = train_sub_out
 
     # Evaluate the substitute model on clean test examples

--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -90,6 +90,7 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
 
     return model, predictions, accuracy
 
+
 class ModelSubstitute(Model):
     def __init__(self, scope, nb_classes, nb_filters=200, **kwargs):
         del kwargs

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -129,7 +129,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     if targeted:
         if viz_enabled:
             # Initialize our array for grid visualization
-            grid_shape = (nb_classes, nb_classes, img_rows, img_cols, 
+            grid_shape = (nb_classes, nb_classes, img_rows, img_cols,
                           nchannels)
             grid_viz_data = np.zeros(grid_shape, dtype='f')
 

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -67,8 +67,8 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                                                   test_end=test_end)
 
     # Obtain Image Parameters
-    img_rows, img_cols, nchannels = X_train.shape[1:4]
-    nb_classes = Y_train.shape[1]
+    img_rows, img_cols, nchannels = x_train.shape[1:4]
+    nb_classes = y_train.shape[1]
 
     # Define input TF placeholder
     x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols,

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -66,8 +66,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
-    # Use label smoothing
-    print(X_train.shape)
+    # Obtain Image Parameters
     img_rows, img_cols, nchannels = X_train.shape[1:4]
     nb_classes = Y_train.shape[1]
 
@@ -107,7 +106,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     # Evaluate the accuracy of the MNIST model on legitimate test examples
     eval_params = {'batch_size': batch_size}
     accuracy = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
-#    assert X_test.shape[0] == test_end - test_start, X_test.shape
+    assert X_test.shape[0] == test_end - test_start, X_test.shape
     print('Test accuracy on legitimate test examples: {0}'.format(accuracy))
     report.clean_train_clean_eval = accuracy
 

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -28,7 +28,7 @@ FLAGS = flags.FLAGS
 
 def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                       test_end=10000, viz_enabled=True, nb_epochs=6,
-                      batch_size=128, nb_classes=10, source_samples=10,
+                      batch_size=128, source_samples=10,
                       learning_rate=0.001, attack_iterations=100,
                       model_path=os.path.join("models", "mnist"),
                       targeted=True):
@@ -51,11 +51,6 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     # Object used to keep track of (and return) key accuracies
     report = AccuracyReport()
 
-    # MNIST-specific dimensions
-    img_rows = 28
-    img_cols = 28
-    channels = 1
-
     # Set TF random seed to improve reproducibility
     tf.set_random_seed(1234)
 
@@ -71,12 +66,20 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
+    # Use label smoothing
+    print(X_train.shape)
+    img_rows, img_cols, nchannels = X_train.shape[1:4]
+    nb_classes = Y_train.shape[1]
+
     # Define input TF placeholder
-    x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols, channels))
+    x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols,
+                                          nchannels))
     y = tf.placeholder(tf.float32, shape=(None, nb_classes))
+    nb_filters = 64
 
     # Define TF model graph
-    model = make_basic_cnn()
+    model = make_basic_cnn(nb_filters, nb_classes,
+                           input_shape=(None, img_rows, img_cols, nchannels))
     preds = model(x)
     print("Defined TensorFlow model graph.")
 
@@ -104,7 +107,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     # Evaluate the accuracy of the MNIST model on legitimate test examples
     eval_params = {'batch_size': batch_size}
     accuracy = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
-    assert X_test.shape[0] == test_end - test_start, X_test.shape
+#    assert X_test.shape[0] == test_end - test_start, X_test.shape
     print('Test accuracy on legitimate test examples: {0}'.format(accuracy))
     report.clean_train_clean_eval = accuracy
 
@@ -126,7 +129,8 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     if targeted:
         if viz_enabled:
             # Initialize our array for grid visualization
-            grid_shape = (nb_classes, nb_classes, img_rows, img_cols, channels)
+            grid_shape = (nb_classes, nb_classes, img_rows, img_cols, 
+                          nchannels)
             grid_viz_data = np.zeros(grid_shape, dtype='f')
 
             adv_inputs = np.array(
@@ -141,7 +145,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
         one_hot[np.arange(nb_classes), np.arange(nb_classes)] = 1
 
         adv_inputs = adv_inputs.reshape(
-            (source_samples * nb_classes, img_rows, img_cols, 1))
+            (source_samples * nb_classes, img_rows, img_cols, nchannels))
         adv_ys = np.array([one_hot] * source_samples,
                           dtype=np.float32).reshape((source_samples *
                                                      nb_classes, nb_classes))
@@ -149,7 +153,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     else:
         if viz_enabled:
             # Initialize our array for grid visualization
-            grid_shape = (nb_classes, 2, img_rows, img_cols, channels)
+            grid_shape = (nb_classes, 2, img_rows, img_cols, nchannels)
             grid_viz_data = np.zeros(grid_shape, dtype='f')
 
             adv_inputs = X_test[idxs]
@@ -221,7 +225,6 @@ def main(argv=None):
     mnist_tutorial_cw(viz_enabled=FLAGS.viz_enabled,
                       nb_epochs=FLAGS.nb_epochs,
                       batch_size=FLAGS.batch_size,
-                      nb_classes=FLAGS.nb_classes,
                       source_samples=FLAGS.source_samples,
                       learning_rate=FLAGS.learning_rate,
                       attack_iterations=FLAGS.attack_iterations,
@@ -233,7 +236,6 @@ if __name__ == '__main__':
     flags.DEFINE_boolean('viz_enabled', True, 'Visualize adversarial ex.')
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
-    flags.DEFINE_integer('nb_classes', 10, 'Number of output classes')
     flags.DEFINE_integer('source_samples', 10, 'Nb of test inputs to attack')
     flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
     flags.DEFINE_string('model_path', os.path.join("models", "mnist"),

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -62,7 +62,7 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
-    print(X_train.shape)
+    # Obtain Image Parameters
     img_rows, img_cols, nchannels = X_train.shape[1:4]
     nb_classes = Y_train.shape[1]
 
@@ -97,7 +97,7 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     # Evaluate the accuracy of the MNIST model on legitimate test examples
     eval_params = {'batch_size': batch_size}
     accuracy = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
-#    assert X_test.shape[0] == test_end - test_start, X_test.shape
+    assert X_test.shape[0] == test_end - test_start, X_test.shape
     print('Test accuracy on legitimate test examples: {0}'.format(accuracy))
     report.clean_train_clean_eval = accuracy
 

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -74,7 +74,8 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     nb_filters = 64
     # Define TF model graph
     model = make_basic_cnn(nb_filters, nb_classes,
-                   input_shape=(None, img_rows, img_cols, nchannels))
+                           input_shape=(None, img_rows, img_cols,
+                                        nchannels))
     preds = model(x)
     print("Defined TensorFlow model graph.")
 

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -63,8 +63,8 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
                                                   test_end=test_end)
 
     # Obtain Image Parameters
-    img_rows, img_cols, nchannels = X_train.shape[1:4]
-    nb_classes = Y_train.shape[1]
+    img_rows, img_cols, nchannels = x_train.shape[1:4]
+    nb_classes = y_train.shape[1]
 
     # Define input TF placeholder
     x = tf.placeholder(tf.float32, shape=(None, img_rows, img_cols,

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -75,8 +75,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
-    # Use label smoothing
-    print(X_train.shape)
+    # Obtain Image Parameters
     img_rows, img_cols, nchannels = X_train.shape[1:4]
     nb_classes = Y_train.shape[1]
 

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -120,7 +120,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
     ckpt = tf.train.get_checkpoint_state(train_dir)
     ckpt_path = False if ckpt is None else ckpt.model_checkpoint_path
-        
+
     if load_model and ckpt_path:
         saver = tf.train.Saver()
         saver.restore(sess, ckpt_path)

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -23,6 +23,7 @@ from keras import backend
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.platform import flags
+import os
 
 FLAGS = flags.FLAGS
 
@@ -69,18 +70,18 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     keras.backend.set_session(sess)
 
     # Get MNIST test data
-    X_train, Y_train, X_test, Y_test = data_mnist(train_start=train_start,
+    x_train, y_train, x_test, y_test = data_mnist(train_start=train_start,
                                                   train_end=train_end,
                                                   test_start=test_start,
                                                   test_end=test_end)
 
     # Obtain Image Parameters
-    img_rows, img_cols, nchannels = X_train.shape[1:4]
-    nb_classes = Y_train.shape[1]
+    img_rows, img_cols, nchannels = x_train.shape[1:4]
+    nb_classes = y_train.shape[1]
 
     if label_smoothing:
         label_smooth = .1
-        Y_train = Y_train.clip(label_smooth / (nb_classes-1),
+        y_train = y_train.clip(label_smooth / (nb_classes-1),
                                1. - label_smooth)
 
     # Define input TF placeholder
@@ -98,7 +99,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     def evaluate():
         # Evaluate the accuracy of the MNIST model on legitimate test examples
         eval_params = {'batch_size': batch_size}
-        acc = model_eval(sess, x, y, preds, X_test, Y_test, args=eval_params)
+        acc = model_eval(sess, x, y, preds, x_test, y_test, args=eval_params)
         report.clean_train_clean_eval = acc
 #        assert X_test.shape[0] == test_end - test_start, X_test.shape
         print('Test accuracy on legitimate examples: %0.4f' % acc)
@@ -130,13 +131,13 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     else:
         print("Model was not loaded, training from scratch.")
         loss = LossCrossEntropy(wrap, smoothing=0.1)
-        train(sess, loss, x, y, X_train, Y_train, evaluate=evaluate,
+        train(sess, loss, x, y, x_train, y_train, evaluate=evaluate,
               args=train_params, save=True, rng=rng)
 
     # Calculate training error
     if testing:
         eval_params = {'batch_size': batch_size}
-        acc = model_eval(sess, x, y, preds, X_train, Y_train, args=eval_params)
+        acc = model_eval(sess, x, y, preds, x_train, y_train, args=eval_params)
         report.train_clean_train_clean_eval = acc
 
     # Initialize the Fast Gradient Sign Method (FGSM) attack object and graph
@@ -151,15 +152,15 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
     # Evaluate the accuracy of the MNIST model on adversarial examples
     eval_par = {'batch_size': batch_size}
-    acc = model_eval(sess, x, y, preds_adv, X_test, Y_test, args=eval_par)
+    acc = model_eval(sess, x, y, preds_adv, x_test, y_test, args=eval_par)
     print('Test accuracy on adversarial examples: %0.4f\n' % acc)
     report.clean_train_adv_eval = acc
 
     # Calculating train error
     if testing:
         eval_par = {'batch_size': batch_size}
-        acc = model_eval(sess, x, y, preds_adv, X_train,
-                         Y_train, args=eval_par)
+        acc = model_eval(sess, x, y, preds_adv, x_train,
+                         y_train, args=eval_par)
         report.train_clean_train_adv_eval = acc
 
     print("Repeating the process, using adversarial training")
@@ -180,29 +181,29 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     def evaluate_2():
         # Accuracy of adversarially trained model on legitimate test inputs
         eval_params = {'batch_size': batch_size}
-        accuracy = model_eval(sess, x, y, preds_2, X_test, Y_test,
+        accuracy = model_eval(sess, x, y, preds_2, x_test, y_test,
                               args=eval_params)
         print('Test accuracy on legitimate examples: %0.4f' % accuracy)
         report.adv_train_clean_eval = accuracy
 
         # Accuracy of the adversarially trained model on adversarial examples
-        accuracy = model_eval(sess, x, y, preds_2_adv, X_test,
-                              Y_test, args=eval_params)
+        accuracy = model_eval(sess, x, y, preds_2_adv, x_test,
+                              y_test, args=eval_params)
         print('Test accuracy on adversarial examples: %0.4f' % accuracy)
         report.adv_train_adv_eval = accuracy
 
     # Perform and evaluate adversarial training
-    train(sess, loss_2, x, y, X_train, Y_train, evaluate=evaluate_2,
+    train(sess, loss_2, x, y, x_train, y_train, evaluate=evaluate_2,
           args=train_params, save=False, rng=rng)
 
     # Calculate training errors
     if testing:
         eval_params = {'batch_size': batch_size}
-        accuracy = model_eval(sess, x, y, preds_2, X_train, Y_train,
+        accuracy = model_eval(sess, x, y, preds_2, x_train, y_train,
                               args=eval_params)
         report.train_adv_train_clean_eval = accuracy
-        accuracy = model_eval(sess, x, y, preds_2_adv, X_train,
-                              Y_train, args=eval_params)
+        accuracy = model_eval(sess, x, y, preds_2_adv, x_train,
+                              y_train, args=eval_params)
         report.train_adv_train_adv_eval = accuracy
 
     return report

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -76,8 +76,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                                                   train_end=train_end,
                                                   test_start=test_start,
                                                   test_end=test_end)
-    # Use label smoothing
-    print(X_train.shape)
+    # Use Image Parameters
     img_rows, img_cols, nchannels = X_train.shape[1:4]
     nb_classes = Y_train.shape[1]
 
@@ -116,7 +115,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
             acc = model_eval(
                 sess, x, y, preds, X_test, Y_test, args=eval_params)
             report.clean_train_clean_eval = acc
-#            assert X_test.shape[0] == test_end - test_start, X_test.shape
+            assert X_test.shape[0] == test_end - test_start, X_test.shape
             print('Test accuracy on legitimate examples: %0.4f' % acc)
         model_train(sess, x, y, preds, X_train, Y_train, evaluate=evaluate,
                     args=train_params, rng=rng, var_list=model.get_params())

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -83,7 +83,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
 
     if label_smoothing:
         label_smooth = .1
-        Y_train = Y_train.clip(label_smooth / 
+        Y_train = Y_train.clip(label_smooth /
                                (nb_classes-1), 1. - label_smooth)
 
     # Define input TF placeholder

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -76,12 +76,12 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
                                                   test_start=test_start,
                                                   test_end=test_end)
     # Use Image Parameters
-    img_rows, img_cols, nchannels = X_train.shape[1:4]
-    nb_classes = Y_train.shape[1]
+    img_rows, img_cols, nchannels = x_train.shape[1:4]
+    nb_classes = y_train.shape[1]
 
     if label_smoothing:
         label_smooth = .1
-        Y_train = Y_train.clip(label_smooth /
+        y_train = y_train.clip(label_smooth /
                                (nb_classes-1), 1. - label_smooth)
 
     # Define input TF placeholder


### PR DESCRIPTION
The cleverhans_tutorial has been written only for MNIST with extensive hard coding of data-set parameters(like image width/height/channels. I have modified the code to handle other data-sets. The user need to only modify utils_mnist.py for his dataset and rest of the code will work out of box. Also I made sure the tutorials work for all image-size & channels. Image parameter are obtained from the X_train variable loaded by utils_mnist.py

Conformed to PEP8