### PR TITLE
 Allow omitted nb_classes parameter in KerasModelWrapper()

### DIFF
--- a/cleverhans/model.py
+++ b/cleverhans/model.py
@@ -13,7 +13,7 @@ class Model(object):
     __metaclass__ = ABCMeta
     O_LOGITS, O_PROBS, O_FEATURES = 'logits probs features'.split()
 
-    def __init__(self, scope=None, nb_classes=10, hparams=None):
+    def __init__(self, scope=None, nb_classes=None, hparams=None):
         """
         Constructor.
         :param scope: str, the name of model.

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -111,7 +111,7 @@ class KerasModelWrapper(Model):
         Create a wrapper for a Keras model
         :param model: A Keras model
         """
-        super(KerasModelWrapper, self).__init__(None, 10, {})
+        super(KerasModelWrapper, self).__init__(None, None, {})
 
         if model is None:
             raise ValueError('model argument must be supplied.')

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -106,12 +106,12 @@ class KerasModelWrapper(Model):
     in-place operations can incur an overhead.
     """
 
-    def __init__(self, model, nb_classes=10):
+    def __init__(self, model):
         """
         Create a wrapper for a Keras model
         :param model: A Keras model
         """
-        super(KerasModelWrapper, self).__init__(None, nb_classes, {})
+        super(KerasModelWrapper, self).__init__(None, 10, {})
 
         if model is None:
             raise ValueError('model argument must be supplied.')

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -106,7 +106,7 @@ class KerasModelWrapper(Model):
     in-place operations can incur an overhead.
     """
 
-    def __init__(self, model, nb_classes):
+    def __init__(self, model, nb_classes=10):
         """
         Create a wrapper for a Keras model
         :param model: A Keras model

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -120,7 +120,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     ckpt = tf.train.get_checkpoint_state(train_dir)
     print(train_dir, ckpt)
     ckpt_path = False if ckpt is None else ckpt.model_checkpoint_path
-    wrap = KerasModelWrapper(model, 10)
+    wrap = KerasModelWrapper(model)
 
     if load_model and ckpt_path:
         saver = tf.train.Saver()
@@ -168,7 +168,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     model_2 = cnn_model(img_rows=img_rows, img_cols=img_cols,
                         channels=nchannels, nb_filters=64,
                         nb_classes=nb_classes)
-    wrap_2 = KerasModelWrapper(model_2, nb_classes)
+    wrap_2 = KerasModelWrapper(model_2)
     preds_2 = model_2(x)
     fgsm2 = FastGradientMethod(wrap_2, sess=sess)
 

--- a/tests_tf/test_utils.py
+++ b/tests_tf/test_utils.py
@@ -84,7 +84,7 @@ class TestUtils(unittest.TestCase):
     def test_get_logits_over_interval(self):
         import tensorflow as tf
         model = cnn_model()
-        wrap = KerasModelWrapper(model, nb_classes=10)
+        wrap = KerasModelWrapper(model)
         fgsm_params = {'eps': .5}
         img = np.ones(shape=(28, 28, 1))
         num_points = 21

--- a/tests_tf/test_utils_keras.py
+++ b/tests_tf/test_utils_keras.py
@@ -27,18 +27,18 @@ class TestKerasModelWrapper(unittest.TestCase):
         self.model = dummy_model()
 
     def test_softmax_layer_name_is_softmax(self):
-        model = KerasModelWrapper(self.model, nb_classes=10)
+        model = KerasModelWrapper(self.model)
         softmax_name = model._get_softmax_name()
         self.assertEqual(softmax_name, 'softmax')
 
     def test_logit_layer_name_is_logits(self):
-        model = KerasModelWrapper(self.model, nb_classes=10)
+        model = KerasModelWrapper(self.model)
         logits_name = model._get_logits_name()
         self.assertEqual(logits_name, 'l2')
 
     def test_get_logits(self):
         import tensorflow as tf
-        model = KerasModelWrapper(self.model, nb_classes=10)
+        model = KerasModelWrapper(self.model)
         x = tf.placeholder(tf.float32, shape=(None, 100))
         preds = model.get_probs(x)
         logits = model.get_logits(x)
@@ -51,7 +51,7 @@ class TestKerasModelWrapper(unittest.TestCase):
 
     def test_get_probs(self):
         import tensorflow as tf
-        model = KerasModelWrapper(self.model, nb_classes=10)
+        model = KerasModelWrapper(self.model)
         x = tf.placeholder(tf.float32, shape=(None, 100))
         preds = model.get_probs(x)
 
@@ -63,13 +63,13 @@ class TestKerasModelWrapper(unittest.TestCase):
         self.assertTrue(np.all(p_val<=1))
 
     def test_get_layer_names(self):
-        model = KerasModelWrapper(self.model, nb_classes=10)
+        model = KerasModelWrapper(self.model)
         layer_names = model.get_layer_names()
         self.assertEqual(layer_names, ['l1', 'l2', 'softmax'])
 
     def test_fprop(self):
         import tensorflow as tf
-        model = KerasModelWrapper(self.model, nb_classes=10)
+        model = KerasModelWrapper(self.model)
         x = tf.placeholder(tf.float32, shape=(None, 100))
         out_dict = model.fprop(x)
 


### PR DESCRIPTION
a36dae6c4d7abf2750871d5884f683243c1e3ce5 introduced the need to pass a `nb_classes` parameter to KerasModelWrapper constructor.

This is not used by KerasModelWrapper instances. More importantly, this breaks code that used KerasModelWrapper before that commit.