### PR TITLE
Travis CI: Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 sudo: required
 dist: trusty
 language: python
+# RUN_FLAKE8 should be set once for each version of Python under test
 matrix:
     include:
         - python: 2.7
@@ -12,6 +13,7 @@ matrix:
           env:
             - KERAS_BACKEND=tensorflow
             - TENSORFLOW_V=1.8.0
+            - RUN_FLAKE8=true
         - python: 3.5
           env:
             - KERAS_BACKEND=tensorflow
@@ -20,6 +22,7 @@ matrix:
           env:
             - KERAS_BACKEND=tensorflow
             - TENSORFLOW_V=1.8.0
+            - RUN_FLAKE8=true
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
@@ -63,6 +66,14 @@ install:
   # install dependencies for adversarial competition eval infra tests
   - pip install google-cloud
   - pip install Pillow
+
+
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    if [[ "$RUN_FLAKE8" ]]; then
+      pip install flake8;
+      flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics;
+    fi
 
 # command to run tests
 script:

--- a/examples/multigpu_advtrain/utils_cifar.py
+++ b/examples/multigpu_advtrain/utils_cifar.py
@@ -31,6 +31,7 @@ import cPickle as pkl
 
 import numpy as np
 import tensorflow as tf
+from six.moves import xrange
 
 # Global constants describing the CIFAR-10 data set.
 IMAGE_HEIGHT = 32

--- a/examples/multigpu_advtrain/utils_svhn.py
+++ b/examples/multigpu_advtrain/utils_svhn.py
@@ -33,6 +33,7 @@ import os
 import numpy as np
 import tensorflow as tf
 import scipy.io as sio
+from six.moves import xrange
 
 # Global constants describing the SVHN data set.
 IMAGE_HEIGHT = 32

--- a/examples/nips17_adversarial_competition/dev_toolkit/validation_tool/validate_submission_lib.py
+++ b/examples/nips17_adversarial_competition/dev_toolkit/validation_tool/validate_submission_lib.py
@@ -15,7 +15,11 @@ import numpy as np
 from PIL import Image
 
 from six import iteritems
-from six import PY3
+
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 
 EXTRACT_COMMAND = {
@@ -255,9 +259,8 @@ class SubmissionValidator(object):
     """
     shell_call(['docker', 'pull', image_name])
     try:
-      image_size = subprocess.check_output(
-          ['docker', 'inspect', '--format={{.Size}}', image_name]).strip()
-      image_size = int(image_size) if PY3 else long(image_size)
+      image_size = long(subprocess.check_output(
+          ['docker', 'inspect', '--format={{.Size}}', image_name]).strip())
     except (ValueError, subprocess.CalledProcessError) as e:
       logging.error('Failed to determine docker image size: %s', e)
       return False

--- a/examples/nips17_adversarial_competition/eval_infra/code/eval_lib/work_data.py
+++ b/examples/nips17_adversarial_competition/eval_infra/code/eval_lib/work_data.py
@@ -14,9 +14,12 @@ import numpy as np
 
 from six import iteritems
 from six import itervalues
-from six import PY3
 from six import text_type
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 # Cloud Datastore constants
 KIND_WORK_TYPE = u'WorkType'
@@ -40,10 +43,7 @@ MAX_WORK_RECORDS_READ = 1000
 
 def get_integer_time():
   """Returns current time in long integer format."""
-  if PY3:
-    return int(time.time())
-  else:
-    return long(time.time())
+  return long(time.time())
 
 
 def is_unclaimed(work):

--- a/examples/nips17_adversarial_competition/eval_infra/code/worker.py
+++ b/examples/nips17_adversarial_competition/eval_infra/code/worker.py
@@ -39,7 +39,12 @@ import uuid
 import eval_lib
 
 from six import iteritems
+from six import text_type
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 # Sleep time while waiting for next available piece of work
 SLEEP_TIME = 30
@@ -692,9 +697,9 @@ class EvaluationWorker(object):
       image_path = '{0}/adversarial_images/{1}/{1}.zip/{2}.png'.format(
           self.round_name, adv_batch_id, adv_img_id)
       adv_batch['images'][adv_img_id] = {
-          'clean_image_id': unicode(clean_image_id),
-          'image_path': unicode(image_path),
-          'image_hash': unicode(hash_val),
+          'clean_image_id': text_type(clean_image_id),
+          'image_path': text_type(image_path),
+          'image_hash': text_type(hash_val),
       }
     # archive all images and copy to storage
     zipped_images_filename = os.path.join(LOCAL_ZIPPED_OUTPUT_DIR,

--- a/examples/nips17_adversarial_competition/eval_infra/validation_tool/validate_submission_lib.py
+++ b/examples/nips17_adversarial_competition/eval_infra/validation_tool/validate_submission_lib.py
@@ -16,8 +16,11 @@ import numpy as np
 from PIL import Image
 
 from six import iteritems
-from six import PY3
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 EXTRACT_COMMAND = {
     '.zip': ['unzip', '${src}', '-d', '${dst}'],
@@ -254,9 +257,8 @@ class SubmissionValidator(object):
     """
     shell_call(['docker', 'pull', image_name])
     try:
-      image_size = subprocess.check_output(
-          ['docker', 'inspect', '--format={{.Size}}', image_name]).strip()
-      image_size = int(image_size) if PY3 else long(image_size)
+      image_size = long(subprocess.check_output(
+          ['docker', 'inspect', '--format={{.Size}}', image_name]).strip())
     except (ValueError, subprocess.CalledProcessError) as e:
       logging.error('Failed to determine docker image size: %s', e)
       return False

--- a/examples/test_imagenet_attacks.py
+++ b/examples/test_imagenet_attacks.py
@@ -28,6 +28,7 @@ from PIL import Image
 import tensorflow as tf
 from tensorflow.contrib import slim
 from tensorflow.contrib.slim.nets import inception
+from six.moves import xrange
 
 from cleverhans.attacks import SPSA
 from cleverhans.devtools.checks import CleverHansTest


### PR DESCRIPTION
Use [flake8](http://flake8.pycqa.org) to look for Python syntax errors or undefined names on both Python 2 and Python 3.

Python 2 tests should pass when #455 is fixed.

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree