### PR TITLE
Updated APIs used in CIFAR-10 attack

### DIFF
--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -14,7 +14,7 @@ from tensorflow.python.platform import flags
 
 from cleverhans.attacks import FastGradientMethod
 from cleverhans.utils_keras import cnn_model
-from cleverhans.utils_tf import train, model_eval, batch_eval
+from cleverhans.utils_tf import train, model_eval, batch_eval, model_train
 
 FLAGS = flags.FLAGS
 
@@ -113,7 +113,7 @@ def main(argv=None):
         'batch_size': FLAGS.batch_size,
         'learning_rate': FLAGS.learning_rate
     }
-    train(sess, x, y, predictions, X_train, Y_train,
+    model_train(sess, x, y, predictions, X_train, Y_train,
           evaluate=evaluate, args=train_params)
 
     # Craft adversarial examples using Fast Gradient Sign Method (FGSM)
@@ -151,7 +151,7 @@ def main(argv=None):
         print('Test accuracy on adversarial examples: ' + str(accuracy_adv))
 
     # Perform adversarial training
-    train(sess, x, y, predictions_2, X_train, Y_train,
+    model_train(sess, x, y, predictions_2, X_train, Y_train,
           predictions_adv=predictions_2_adv, evaluate=evaluate_2,
           args=train_params)
 


### PR DESCRIPTION
Adapt the train() api to be compatible with the latest version of utils_tf, so that the script is runnable again. 