### PR TITLE
Handle deprecated messages caused by tf.nn.softmax_cross_entropy_with_logits

### DIFF
--- a/cleverhans/compat.py
+++ b/cleverhans/compat.py
@@ -100,9 +100,9 @@ def softmax_cross_entropy_with_logits(sentinel=None, labels=None, logits=None, d
         raise ValueError("Both labels and logits must be provided.")
 
     try:
-        y = tf.stop_gradient(y)
+        labels = tf.stop_gradient(labels)
         loss = tf.nn.softmax_cross_entropy_with_logits_v2(
-            labels=y, logits=logits, dim=dim)
+            labels=labels, logits=logits, dim=dim)
     except AttributeError:
         warning = "Running on tensorflow version " + \
             LooseVersion(tf.__version__).vstring + \

--- a/cleverhans/compat.py
+++ b/cleverhans/compat.py
@@ -87,7 +87,10 @@ def reduce_any(input_tensor, axis=None, keepdims=None,
                            reduction_indices=reduction_indices)
 
 
-def softmax_cross_entropy_with_logits(sentinel=None, labels=None, logits=None, dim=-1):
+def softmax_cross_entropy_with_logits(sentinel=None,
+                                      labels=None,
+                                      logits=None,
+                                      dim=-1):
     """
     Wrapper around tf.nn.softmax_cross_entropy_with_logits_v2 to handle
     deprecated warning
@@ -95,7 +98,8 @@ def softmax_cross_entropy_with_logits(sentinel=None, labels=None, logits=None, d
     # Make sure that all arguments were passed as named arguments.
     if sentinel is not None:
         raise ValueError("Only call `%s` with "
-                         "named arguments (labels=..., logits=..., ...)" % name)
+                         "named arguments (labels=..., logits=..., ...)"
+                         % name)
     if labels is None or logits is None:
         raise ValueError("Both labels and logits must be provided.")
 

--- a/cleverhans/compat.py
+++ b/cleverhans/compat.py
@@ -23,9 +23,9 @@ def reduce_function(op_func, input_tensor, axis=None, keepdims=None,
 
     if LooseVersion(tf.__version__) < LooseVersion('1.8.0'):
         warning = "Running on tensorflow version " + \
-                   LooseVersion(tf.__version__).vstring + \
-                   ". This version will not be supported by CleverHans" + \
-                   "in the future."
+            LooseVersion(tf.__version__).vstring + \
+            ". This version will not be supported by CleverHans" + \
+            "in the future."
         warnings.warn(warning)
         out = op_func(input_tensor, axis=axis,
                       keep_dims=keepdims, name=name,
@@ -85,3 +85,31 @@ def reduce_any(input_tensor, axis=None, keepdims=None,
     return reduce_function(tf.reduce_any, input_tensor, axis=axis,
                            keepdims=keepdims, name=name,
                            reduction_indices=reduction_indices)
+
+
+def softmax_cross_entropy_with_logits(sentinel=None, labels=None, logits=None, dim=-1):
+    """
+    Wrapper around tf.nn.softmax_cross_entropy_with_logits_v2 to handle
+    deprecated warning
+    """
+    # Make sure that all arguments were passed as named arguments.
+    if sentinel is not None:
+        raise ValueError("Only call `%s` with "
+                         "named arguments (labels=..., logits=..., ...)" % name)
+    if labels is None or logits is None:
+        raise ValueError("Both labels and logits must be provided.")
+
+    try:
+        y = tf.stop_gradient(y)
+        loss = tf.nn.softmax_cross_entropy_with_logits_v2(
+            labels=y, logits=logits, dim=dim)
+    except AttributeError:
+        warning = "Running on tensorflow version " + \
+            LooseVersion(tf.__version__).vstring + \
+            ". This version will not be supported by CleverHans" + \
+            "in the future."
+        warnings.warn(warning)
+        loss = tf.nn.softmax_cross_entropy_with_logits(
+            labels=labels, logits=logits, dim=dim)
+
+    return loss

--- a/cleverhans/compat.py
+++ b/cleverhans/compat.py
@@ -24,8 +24,8 @@ def reduce_function(op_func, input_tensor, axis=None, keepdims=None,
     if LooseVersion(tf.__version__) < LooseVersion('1.8.0'):
         warning = "Running on tensorflow version " + \
             LooseVersion(tf.__version__).vstring + \
-            ". This version will not be supported by CleverHans" + \
-            "in the future."
+            ". Support for this version in CleverHans is deprecated " + \
+            "and may be removed on or after 2019-01-26"
         warnings.warn(warning)
         out = op_func(input_tensor, axis=axis,
                       keep_dims=keepdims, name=name,
@@ -110,8 +110,8 @@ def softmax_cross_entropy_with_logits(sentinel=None,
     except AttributeError:
         warning = "Running on tensorflow version " + \
             LooseVersion(tf.__version__).vstring + \
-            ". This version will not be supported by CleverHans" + \
-            "in the future."
+            ". Support for this version in CleverHans is deprecated " + \
+            "and may be removed on or after 2019-01-26"
         warnings.warn(warning)
         loss = tf.nn.softmax_cross_entropy_with_logits(
             labels=labels, logits=logits, dim=dim)

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -1,11 +1,9 @@
-from distutils.version import LooseVersion
 import json
 import os
 
 from .model import Model
 from .compat import softmax_cross_entropy_with_logits
 import tensorflow as tf
-import warnings
 
 
 class Loss(object):

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -16,6 +16,7 @@ from .utils import batch_indices, _ArgsWrapper, create_logger
 from cleverhans.compat import reduce_sum, reduce_mean
 from cleverhans.compat import reduce_max, reduce_min
 from cleverhans.compat import reduce_any
+from cleverhans.compat import softmax_cross_entropy_with_logits
 
 _logger = create_logger("cleverhans.utils.tf")
 
@@ -37,18 +38,7 @@ def model_loss(y, model, mean=True):
     else:
         logits = model
 
-    try:
-        y = tf.stop_gradient(y)
-        out = tf.nn.softmax_cross_entropy_with_logits_v2(
-                                                logits=logits, labels=y)
-    except AttributeError:
-        warning = "Running on tensorflow version " + \
-                   LooseVersion(tf.__version__).vstring + \
-                   ". This version will not be supported by CleverHans" + \
-                   "in the future."
-        warnings.warn(warning)
-        out = tf.nn.softmax_cross_entropy_with_logits(
-                                                logits=logits, labels=y)
+    out = softmax_cross_entropy_with_logits(logits=logits, labels=y)
 
     if mean:
         out = reduce_mean(out)


### PR DESCRIPTION
#397 
Use `tf.nn.softmax_cross_entropy_with_logits_v2` instead of `tf.nn.softmax_cross_entropy_with_logits`, which causes deprecated warnings (e.g. when running `cleverhans_tutorials/mnist_tutorial_tf.py`) for Tensorflow 1.8.