### PR TITLE
Moving a snippet of code to a better place

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -100,11 +100,6 @@ class Attack(object):
         class_name = str(self.__class__).split(".")[-1][:-2]
         _logger.info("Constructing new graph for attack " + class_name)
 
-        # remove the None arguments, they are just left blank
-        for k in list(feedable.keys()):
-            if feedable[k] is None:
-                del feedable[k]
-
         # process all of the rest and create placeholders for them
         new_kwargs = dict(x for x in fixed.items())
         for name, value in feedable.items():
@@ -147,6 +142,11 @@ class Attack(object):
                              " provided")
 
         fixed, feedable, hash_key = self.construct_variables(kwargs)
+
+        # remove the None arguments, they are just left blank
+        for k in list(feedable.keys()):
+            if feedable[k] is None:
+                del feedable[k]
 
         if hash_key not in self.graphs:
             self.construct_graph(fixed, feedable, x_val, hash_key)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -100,6 +100,11 @@ class Attack(object):
         class_name = str(self.__class__).split(".")[-1][:-2]
         _logger.info("Constructing new graph for attack " + class_name)
 
+        # remove the None arguments, they are just left blank
+        for k in list(feedable.keys()):
+            if feedable[k] is None:
+                del feedable[k]
+
         # process all of the rest and create placeholders for them
         new_kwargs = dict(x for x in fixed.items())
         for name, value in feedable.items():
@@ -143,13 +148,13 @@ class Attack(object):
 
         fixed, feedable, hash_key = self.construct_variables(kwargs)
 
-        # remove the None arguments, they are just left blank
-        for k in list(feedable.keys()):
-            if feedable[k] is None:
-                del feedable[k]
-
         if hash_key not in self.graphs:
             self.construct_graph(fixed, feedable, x_val, hash_key)
+        else:
+            # remove the None arguments, they are just left blank
+            for k in list(feedable.keys()):
+                if feedable[k] is None:
+                    del feedable[k]
 
         x, new_kwargs, x_adv = self.graphs[hash_key]
 


### PR DESCRIPTION
As part of creating graph, None arguments are removed. This works as expected, but when generate_np is called in a loop, graph will be constructed only during first iteration. So further calls to generate_np can contain None arguments(as they were removed in function construct_graph) which result in following code to throw error:

`        for name in feedable:
             feed_dict[new_kwargs[name]] = feedable[name]`

None arguments should be removed for every call to generate_np so that a single class instantiation could be used.