### PR TITLE
Add PyTorch as extra and add PyTorch CI jobs to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,9 @@ script:
   - nosetests -v --nologcapture -w examples/nips17_adversarial_competition/eval_infra/code/ eval_lib/tests/
   # --nologcapture: avoids a large amount of unnecessary tensorflow output
   # --stop: stop on first error. Gives feedback from travis faster
-  - nosetests -v --nologcapture --stop cleverhans
   - if [[ "$PYTORCH" == True ]]; then
       nosetests --nologcapture -v --stop tests_pytorch;
+    elif [[ "$PYTORCH" == False ]]; then
+      nosetests -v --nologcapture --stop cleverhans;
+      nosetests --nologcapture -v --stop tests_tf;
     fi
-  - nosetests --nologcapture -v --stop tests_tf

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,15 @@
 sudo: required
 dist: trusty
 language: python
-matrix:
-    include:
-        - python: 2.7
-          env:
-            - KERAS_BACKEND=tensorflow
-            - TENSORFLOW_V=1.4.1
-        - python: 2.7
-          env:
-            - KERAS_BACKEND=tensorflow
-            - TENSORFLOW_V=1.8.0
-        - python: 3.5
-          env:
-            - KERAS_BACKEND=tensorflow
-            - TENSORFLOW_V=1.4.1
-        - python: 3.5
-          env:
-            - KERAS_BACKEND=tensorflow
-            - TENSORFLOW_V=1.8.0
+python:
+  - 2.7
+  - 3.5
+env:
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.4.1 PYTORCH=False
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.8.0 PYTORCH=False
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.4.1 PYTORCH=True
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.8.0 PYTORCH=True
+
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
@@ -52,8 +43,9 @@ install:
     fi
 
   - time pip install -q -e ".[test]"
-  - pip install torch==0.4.0 torchvision==0.2.1 -q
-
+  - if [[ "$PYTORCH" == True ]]; then
+      pip install torch==0.4.0 torchvision==0.2.1 -q;
+    fi
   # workaround for version incompatibility between the scipy version in conda
   # and the system-provided /usr/lib/x86_64-linux-gnu/libstdc++.so.6
   # by installing a conda-provided libgcc and adding it to the load path
@@ -80,5 +72,7 @@ script:
   # --nologcapture: avoids a large amount of unnecessary tensorflow output
   # --stop: stop on first error. Gives feedback from travis faster
   - nosetests -v --nologcapture --stop cleverhans
-  - nosetests --nologcapture -v --stop tests_pytorch
+  - if [[ "$PYTORCH" == True ]]; then
+      nosetests --nologcapture -v --stop tests_pytorch;
+    fi
   - nosetests --nologcapture -v --stop tests_tf

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setup(name='cleverhans',
           "test": [
               "keras == 2.1.5",  # Keras 2.1.6 is incompatible with TF 1.4
           ],
+          "pytorch": ["torch==0.4.0", "torchvision==0.2.1"],
       },
       packages=find_packages())


### PR DESCRIPTION
Fixes #452.

This PR:
 - Adds `PyTorch` based dependencies as an [extra](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) in `setup.py`
 - Adds PyTorch-based CI jobs (note: I made some changes to the test running such that total CI time is kept under 1 hour)

In the future, if users wish to install with PyTorch extra dependencies, they can do: 

```
pip install -e . cleverhans[pytorch]
```
