### PR TITLE
Handle deprecated warning from tf.reduce_*

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -593,7 +593,7 @@ class MomentumIterativeMethod(Attack):
                     reduce_sum(tf.abs(m), red_ind, keepdims=True))
                 normalized_grad = m / norm
             elif self.ord == 2:
-                square = tf.reduce_sum(tf.square(m), red_ind, keepdims=True)
+                square = reduce_sum(tf.square(m), red_ind, keepdims=True)
                 norm = tf.sqrt(tf.maximum(avoid_zero_div, square))
                 normalized_grad = m / norm
             else:

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -403,7 +403,7 @@ class BasicIterativeMethod(Attack):
 
         # Fix labels to the first model predictions for loss computation
         model_preds = self.model.get_probs(x)
-        preds_max = tf.reduce_max(model_preds, 1, keep_dims=True)
+        preds_max = reduce_max(model_preds, 1, keepdims=True)
         if self.y_target is not None:
             y = self.y_target
             targeted = True
@@ -560,7 +560,7 @@ class MomentumIterativeMethod(Attack):
 
         # Fix labels to the first model predictions for loss computation
         y, nb_classes = self.get_or_guess_labels(x, kwargs)
-        y = y / tf.reduce_sum(y, 1, keep_dims=True)
+        y = y / reduce_sum(y, 1, keepdims=True)
         targeted = (self.y_target is not None)
 
         from . import utils_tf
@@ -582,7 +582,7 @@ class MomentumIterativeMethod(Attack):
             avoid_zero_div = tf.cast(1e-12, grad.dtype)
             grad = grad / tf.maximum(
                 avoid_zero_div,
-                tf.reduce_mean(tf.abs(grad), red_ind, keep_dims=True))
+                reduce_mean(tf.abs(grad), red_ind, keepdims=True))
             m = self.decay_factor * m + grad
 
             if self.ord == np.inf:
@@ -590,10 +590,10 @@ class MomentumIterativeMethod(Attack):
             elif self.ord == 1:
                 norm = tf.maximum(
                     avoid_zero_div,
-                    tf.reduce_sum(tf.abs(m), red_ind, keep_dims=True))
+                    reduce_sum(tf.abs(m), red_ind, keepdims=True))
                 normalized_grad = m / norm
             elif self.ord == 2:
-                square = tf.reduce_sum(tf.square(m), red_ind, keep_dims=True)
+                square = tf.reduce_sum(tf.square(m), red_ind, keepdims=True)
                 norm = tf.sqrt(tf.maximum(avoid_zero_div, square))
                 normalized_grad = m / norm
             else:


### PR DESCRIPTION
Handle deprecated warning from `tf.reduce_*` in `BasicIterativeMethod` and `MomentumIterativeMethod`.

By the way, this should have already been handled in c02b0d1, but appears again after 3a362785. 