### PR TITLE
Migrate from old and deprecated API to the new one

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -571,7 +571,8 @@ class MomentumIterativeMethod(Attack):
 
         def body(i, ax, m):
             preds = self.model.get_probs(ax)
-            loss = loss_module.attack_softmax_cross_entropy(y, preds, mean=False)
+            loss = loss_module.attack_softmax_cross_entropy(
+                y, preds, mean=False)
             if targeted:
                 loss = -loss
 

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -564,13 +564,14 @@ class MomentumIterativeMethod(Attack):
         targeted = (self.y_target is not None)
 
         from . import utils_tf
+        from . import loss as loss_module
 
         def cond(i, _, __):
             return tf.less(i, self.nb_iter)
 
         def body(i, ax, m):
             preds = self.model.get_probs(ax)
-            loss = utils_tf.model_loss(y, preds, mean=False)
+            loss = loss_module.attack_softmax_cross_entropy(y, preds, mean=False)
             if targeted:
                 loss = -loss
 

--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -14,7 +14,7 @@ from tensorflow.python.platform import flags
 
 from cleverhans.attacks import FastGradientMethod
 from cleverhans.utils_keras import cnn_model
-from cleverhans.utils_tf import model_train, train, model_eval, batch_eval
+from cleverhans.utils_tf import train, model_eval, batch_eval
 
 FLAGS = flags.FLAGS
 
@@ -113,8 +113,8 @@ def main(argv=None):
         'batch_size': FLAGS.batch_size,
         'learning_rate': FLAGS.learning_rate
     }
-    model_train(sess, x, y, predictions, X_train, Y_train,
-                evaluate=evaluate, args=train_params)
+    train(sess, x, y, predictions, X_train, Y_train,
+          evaluate=evaluate, args=train_params)
 
     # Craft adversarial examples using Fast Gradient Sign Method (FGSM)
     fgsm = FastGradientMethod(model)
@@ -151,9 +151,9 @@ def main(argv=None):
         print('Test accuracy on adversarial examples: ' + str(accuracy_adv))
 
     # Perform adversarial training
-    model_train(sess, x, y, predictions_2, X_train, Y_train,
-                predictions_adv=predictions_2_adv, evaluate=evaluate_2,
-                args=train_params)
+    train(sess, x, y, predictions_2, X_train, Y_train,
+          predictions_adv=predictions_2_adv, evaluate=evaluate_2,
+          args=train_params)
 
     # Evaluate the accuracy of the CIFAR10 model on adversarial examples
     accuracy = model_eval(sess, x, y, predictions_2_adv, X_test, Y_test,


### PR DESCRIPTION
As shown in #423, APIs like `model_train` and `model_loss` in `utils_tf.py` are deprecated. Change them to `train` and `attack_softmax_cross_entropy` instead.