### PR TITLE
Add Spatial Transformation Attack

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -1878,7 +1878,8 @@ class SpatialTransformationMethod(Attack):
         :param x: The model's symbolic inputs.
         :param batch_size: (optional int) The size of batch during evaluation.
         :param n_samples: (optional) The number of transformations sampled to
-                          construct the attack.
+                          construct the attack. Set it to None to run
+                          full grid attack.
         :param dx_min: (optional float) Minimum translation ratio along x-axis.
         :param dx_max: (optional float) Maximum translation ratio along x-axis.
         :param n_dxs: (optional int) Number of discretized translation ratios
@@ -1912,7 +1913,7 @@ class SpatialTransformationMethod(Attack):
 
     def parse_params(self,
                      batch_size=128,
-                     n_samples=10,
+                     n_samples=None,
                      dx_min=-0.1,
                      dx_max=0.1,
                      n_dxs=2,
@@ -1939,9 +1940,6 @@ class SpatialTransformationMethod(Attack):
         self.angle_max = angle_max
         self.n_angles = n_angles
 
-        if self.angle_min < -30 or self.angle_max > 30:
-            raise ValueError("The value of angle must be bounded "
-                             "within [-30, 30]")
         if self.dx_min < -1 or self.dy_min < -1 or \
            self.dx_max > 1 or self.dy_max > 1:
             raise ValueError("The value of translation must be bounded "

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -1876,20 +1876,21 @@ class SpatialTransformationMethod(Attack):
         """
         Generate symbolic graph for adversarial examples and return.
         :param x: The model's symbolic inputs.
-        :param eps: (optional float) attack step size (input variation)
-        :param ord: (optional) Order of the norm (mimics NumPy).
-                    Possible values: np.inf, 1 or 2.
-        :param y: (optional) A tensor with the model labels. Only provide
-                  this parameter if you'd like to use true labels when crafting
-                  adversarial samples. Otherwise, model predictions are used as
-                  labels to avoid the "label leaking" effect (explained in this
-                  paper: https://arxiv.org/abs/1611.01236). Default is None.
-                  Labels should be one-hot-encoded.
-        :param y_target: (optional) A tensor with the labels to target. Leave
-                         y_target=None if y is also set. Labels should be
-                         one-hot-encoded.
-        :param clip_min: (optional float) Minimum input component value
-        :param clip_max: (optional float) Maximum input component value
+        :param batch_size: (optional int) The size of batch during evaluation.
+        :param n_samples: (optional) The number of transformations sampled to
+                          construct the attack.
+        :param dx_min: (optional float) Minimum translation ratio along x-axis.
+        :param dx_max: (optional float) Maximum translation ratio along x-axis.
+        :param n_dxs: (optional int) Number of discretized translation ratios
+                      along x-axis.
+        :param dy_min: (optional float) Minimum translation ratio along y-axis.
+        :param dy_max: (optional float) Maximum translation ratio along y-axis.
+        :param n_dys: (optional int) Number of discretized translation ratios
+                      along y-axis.
+        :param angle_min: (optional float) Largest counter-clockwise rotation
+                          angle.
+        :param angle_max: (optional float) Largest clockwise rotation angle.
+        :param n_angles: (optional int) Number of discretized angles.
         """
         # Parse and save attack-specific parameters
         assert self.parse_params(**kwargs)
@@ -1923,6 +1924,8 @@ class SpatialTransformationMethod(Attack):
                      n_angles=6,
                      **kwargs):
         """
+        Take in a dictionary of parameters and applies attack-specific checks
+        before saving them as attributes.
         """
         self.batch_size = batch_size
         self.n_samples = n_samples

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -1935,11 +1935,14 @@ def _apply_transformation(x, dx, dy, angle, batch_size):
                   0, 1, -dy*width, 0, 0] * batch_size, dtype=np.float32)
     theta = tf.constant(M, shape=(batch_size, 8))
 
-    # transfrom image
+
+    # Pad the image to prevent two-step rotation / translation
+    x = tf.pad(x, [[0, 0], [50, 50], [50, 50], [0, 0]], 'CONSTANT')
+    # Rotate and translate the image
     x = tf.contrib.image.rotate(x, angle, interpolation='BILINEAR')
     x = tf.contrib.image.transform(x, theta, interpolation='BILINEAR')
 
-    return x
+    return tf.image.resize_image_with_crop_or_pad(x, height, width)
 
 
 def spm(x, model, batch_size=128, y=None, n_samples=None, dx_min=-0.1,

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -1935,9 +1935,9 @@ def _apply_transformation(x, dx, dy, angle, batch_size):
                   0, 1, -dy*width, 0, 0] * batch_size, dtype=np.float32)
     theta = tf.constant(M, shape=(batch_size, 8))
 
-
     # Pad the image to prevent two-step rotation / translation
-    x = tf.pad(x, [[0, 0], [50, 50], [50, 50], [0, 0]], 'CONSTANT')
+    x = tf.pad(x, [[0, 0], [height, height], [width, width], [0, 0]],
+               'CONSTANT')
     # Rotate and translate the image
     x = tf.contrib.image.rotate(x, angle, interpolation='BILINEAR')
     x = tf.contrib.image.transform(x, theta, interpolation='BILINEAR')

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -1945,7 +1945,8 @@ def _transformer(U, theta, out_size, name='SpatialTransformer', **kwargs):
     .. [1]  Spatial Transformer Networks
             Max Jaderberg, Karen Simonyan, Andrew Zisserman, Koray Kavukcuoglu
             Submitted on 5 Jun 2015
-    .. [2]  https://github.com/skaae/transformer_network/blob/master/transformerlayer.py
+    .. [2]  https://github.com/skaae/transformer_network/
+              blob/master/transformerlayer.py
     Notes
     -----
     To initialize the network to the identity transform init
@@ -1959,7 +1960,8 @@ def _transformer(U, theta, out_size, name='SpatialTransformer', **kwargs):
     def _repeat(x, n_repeats):
         with tf.variable_scope('_repeat'):
             rep = tf.transpose(
-                tf.expand_dims(tf.ones(shape=tf.stack([n_repeats, ])), 1), [1, 0])
+                tf.expand_dims(tf.ones(
+                    shape=tf.stack([n_repeats, ])), 1), [1, 0])
             rep = tf.cast(rep, 'int32')
             x = tf.matmul(tf.reshape(x, (-1, 1)), rep)
             return tf.reshape(x, [-1])
@@ -2035,7 +2037,8 @@ def _transformer(U, theta, out_size, name='SpatialTransformer', **kwargs):
             #  ones = np.ones(np.prod(x_t.shape))
             #  grid = np.vstack([x_t.flatten(), y_t.flatten(), ones])
             x_t = tf.matmul(tf.ones(shape=tf.stack([height, 1])),
-                            tf.transpose(tf.expand_dims(tf.linspace(-1.0, 1.0, width), 1), [1, 0]))
+                            tf.transpose(tf.expand_dims(
+                                tf.linspace(-1.0, 1.0, width), 1), [1, 0]))
             y_t = tf.matmul(tf.expand_dims(tf.linspace(-1.0, 1.0, height), 1),
                             tf.ones(shape=tf.stack([1, width])))
 
@@ -2078,7 +2081,8 @@ def _transformer(U, theta, out_size, name='SpatialTransformer', **kwargs):
                 out_size)
 
             output = tf.reshape(
-                input_transformed, tf.stack([num_batch, out_height, out_width, num_channels]))
+                input_transformed,
+                tf.stack([num_batch, out_height, out_width, num_channels]))
             return output
 
     with tf.variable_scope(name):

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -1926,10 +1926,6 @@ def margin_logit_loss(model_logits, label, num_classes=10):
     return loss
 
 
-from six.moves import xrange
-import tensorflow as tf
-
-
 def _transformer(U, theta, out_size, name='SpatialTransformer', **kwargs):
     """Spatial Transformer Layer
     Implements a spatial transformer layer as described in [1]_.

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -1926,6 +1926,170 @@ def margin_logit_loss(model_logits, label, num_classes=10):
     return loss
 
 
+from six.moves import xrange
+import tensorflow as tf
+
+
+def _transformer(U, theta, out_size, name='SpatialTransformer', **kwargs):
+    """Spatial Transformer Layer
+    Implements a spatial transformer layer as described in [1]_.
+    Based on [2]_ and edited by David Dao for Tensorflow.
+    Parameters
+    ----------
+    U : float
+        The output of a convolutional net should have the
+        shape [num_batch, height, width, num_channels].
+    theta: float
+        The output of the
+        localisation network should be [num_batch, 6].
+    out_size: tuple of two ints
+        The size of the output of the network (height, width)
+    References
+    ----------
+    .. [1]  Spatial Transformer Networks
+            Max Jaderberg, Karen Simonyan, Andrew Zisserman, Koray Kavukcuoglu
+            Submitted on 5 Jun 2015
+    .. [2]  https://github.com/skaae/transformer_network/blob/master/transformerlayer.py
+    Notes
+    -----
+    To initialize the network to the identity transform init
+    ``theta`` to :
+        identity = np.array([[1., 0., 0.],
+                             [0., 1., 0.]])
+        identity = identity.flatten()
+        theta = tf.Variable(initial_value=identity)
+    """
+
+    def _repeat(x, n_repeats):
+        with tf.variable_scope('_repeat'):
+            rep = tf.transpose(
+                tf.expand_dims(tf.ones(shape=tf.stack([n_repeats, ])), 1), [1, 0])
+            rep = tf.cast(rep, 'int32')
+            x = tf.matmul(tf.reshape(x, (-1, 1)), rep)
+            return tf.reshape(x, [-1])
+
+    def _interpolate(im, x, y, out_size):
+        with tf.variable_scope('_interpolate'):
+            # constants
+            num_batch = tf.shape(im)[0]
+            height = tf.shape(im)[1]
+            width = tf.shape(im)[2]
+            channels = tf.shape(im)[3]
+
+            x = tf.cast(x, 'float32')
+            y = tf.cast(y, 'float32')
+            height_f = tf.cast(height, 'float32')
+            width_f = tf.cast(width, 'float32')
+            out_height = out_size[0]
+            out_width = out_size[1]
+            zero = tf.zeros([], dtype='int32')
+            max_y = tf.cast(tf.shape(im)[1] - 1, 'int32')
+            max_x = tf.cast(tf.shape(im)[2] - 1, 'int32')
+
+            # scale indices from [-1, 1] to [0, width/height]
+            x = (x + 1.0)*(width_f) / 2.0
+            y = (y + 1.0)*(height_f) / 2.0
+
+            # do sampling
+            x0 = tf.cast(tf.floor(x), 'int32')
+            x1 = x0 + 1
+            y0 = tf.cast(tf.floor(y), 'int32')
+            y1 = y0 + 1
+
+            x0 = tf.clip_by_value(x0, zero, max_x)
+            x1 = tf.clip_by_value(x1, zero, max_x)
+            y0 = tf.clip_by_value(y0, zero, max_y)
+            y1 = tf.clip_by_value(y1, zero, max_y)
+            dim2 = width
+            dim1 = width*height
+            base = _repeat(tf.range(num_batch)*dim1, out_height*out_width)
+            base_y0 = base + y0*dim2
+            base_y1 = base + y1*dim2
+            idx_a = base_y0 + x0
+            idx_b = base_y1 + x0
+            idx_c = base_y0 + x1
+            idx_d = base_y1 + x1
+
+            # use indices to lookup pixels in the flat image and restore
+            # channels dim
+            im_flat = tf.reshape(im, tf.stack([-1, channels]))
+            im_flat = tf.cast(im_flat, 'float32')
+            Ia = tf.gather(im_flat, idx_a)
+            Ib = tf.gather(im_flat, idx_b)
+            Ic = tf.gather(im_flat, idx_c)
+            Id = tf.gather(im_flat, idx_d)
+
+            # and finally calculate interpolated values
+            x0_f = tf.cast(x0, 'float32')
+            x1_f = tf.cast(x1, 'float32')
+            y0_f = tf.cast(y0, 'float32')
+            y1_f = tf.cast(y1, 'float32')
+            wa = tf.expand_dims(((x1_f-x) * (y1_f-y)), 1)
+            wb = tf.expand_dims(((x1_f-x) * (y-y0_f)), 1)
+            wc = tf.expand_dims(((x-x0_f) * (y1_f-y)), 1)
+            wd = tf.expand_dims(((x-x0_f) * (y-y0_f)), 1)
+            output = tf.add_n([wa*Ia, wb*Ib, wc*Ic, wd*Id])
+            return output
+
+    def _meshgrid(height, width):
+        with tf.variable_scope('_meshgrid'):
+            # This should be equivalent to:
+            #  x_t, y_t = np.meshgrid(np.linspace(-1, 1, width),
+            #                         np.linspace(-1, 1, height))
+            #  ones = np.ones(np.prod(x_t.shape))
+            #  grid = np.vstack([x_t.flatten(), y_t.flatten(), ones])
+            x_t = tf.matmul(tf.ones(shape=tf.stack([height, 1])),
+                            tf.transpose(tf.expand_dims(tf.linspace(-1.0, 1.0, width), 1), [1, 0]))
+            y_t = tf.matmul(tf.expand_dims(tf.linspace(-1.0, 1.0, height), 1),
+                            tf.ones(shape=tf.stack([1, width])))
+
+            x_t_flat = tf.reshape(x_t, (1, -1))
+            y_t_flat = tf.reshape(y_t, (1, -1))
+
+            ones = tf.ones_like(x_t_flat)
+            grid = tf.concat(axis=0, values=[x_t_flat, y_t_flat, ones])
+            return grid
+
+    def _transform(theta, input_dim, out_size):
+        with tf.variable_scope('_transform'):
+            num_batch = tf.shape(input_dim)[0]
+            height = tf.shape(input_dim)[1]
+            width = tf.shape(input_dim)[2]
+            num_channels = tf.shape(input_dim)[3]
+            theta = tf.reshape(theta, (-1, 2, 3))
+            theta = tf.cast(theta, 'float32')
+
+            # grid of (x_t, y_t, 1), eq (1) in ref [1]
+            height_f = tf.cast(height, 'float32')
+            width_f = tf.cast(width, 'float32')
+            out_height = out_size[0]
+            out_width = out_size[1]
+            grid = _meshgrid(out_height, out_width)
+            grid = tf.expand_dims(grid, 0)
+            grid = tf.reshape(grid, [-1])
+            grid = tf.tile(grid, tf.stack([num_batch]))
+            grid = tf.reshape(grid, tf.stack([num_batch, 3, -1]))
+
+            # Transform A x (x_t, y_t, 1)^T -> (x_s, y_s)
+            T_g = tf.matmul(theta, grid)
+            x_s = tf.slice(T_g, [0, 0, 0], [-1, 1, -1])
+            y_s = tf.slice(T_g, [0, 1, 0], [-1, 1, -1])
+            x_s_flat = tf.reshape(x_s, [-1])
+            y_s_flat = tf.reshape(y_s, [-1])
+
+            input_transformed = _interpolate(
+                input_dim, x_s_flat, y_s_flat,
+                out_size)
+
+            output = tf.reshape(
+                input_transformed, tf.stack([num_batch, out_height, out_width, num_channels]))
+            return output
+
+    with tf.variable_scope(name):
+        output = _transform(theta, U, out_size)
+        return output
+
+
 def spm(x, model, batch_size=128, y=None, n_samples=10, dx_min=-0.1,
         dx_max=0.1, n_dxs=5, dy_min=-0.1, dy_max=0.1, n_dys=5,
         angle_min=-30, angle_max=30, n_angles=11):
@@ -1955,7 +2119,6 @@ def spm(x, model, batch_size=128, y=None, n_samples=10, dx_min=-0.1,
     sampled_angles = np.random.choice(angles, n_samples)
 
     import math
-    from cleverhans.spatial_transformer import transformer
 
     adv_xs = []
     accs = []
@@ -1970,7 +2133,7 @@ def spm(x, model, batch_size=128, y=None, n_samples=10, dx_min=-0.1,
 
         # Transform the input and get preds
         out_size = (img_rows, img_cols)
-        adv_xs.append(tf.reshape(transformer(x, theta, out_size),
+        adv_xs.append(tf.reshape(_transformer(x, theta, out_size),
                                  (-1, img_rows, img_cols, 1)))
         preds_adv = model.get_logits(adv_xs[-1])
 

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -23,6 +23,7 @@ from cleverhans.attacks import DeepFool
 from cleverhans.attacks import MadryEtAl
 from cleverhans.attacks import FastFeatureAdversaries
 from cleverhans.attacks import LBFGS
+from cleverhans.attacks import SpatialTransformationMethod
 from cleverhans.model import Model
 from cleverhans_tutorials.tutorial_models import HeReLuNormalInitializer
 
@@ -1010,6 +1011,48 @@ class TestLBFGS(CleverHansTest):
 
         self.assertTrue(-0.201 < np.min(x_adv))
         self.assertTrue(np.max(x_adv) < .301)
+
+
+class TestSpatialTransformationMethod(CleverHansTest):
+    def setUp(self):
+        super(TestSpatialTransformationMethod, self).setUp()
+
+        self.sess = tf.Session()
+        self.model = DummyModel()
+        self.attack = SpatialTransformationMethod(self.model, sess=self.sess)
+
+        # initialize model
+        with tf.name_scope('dummy_model'):
+            self.model(tf.placeholder(tf.float32, shape=(None, 2, 2, 3)))
+        self.sess.run(tf.global_variables_initializer())
+
+    def test_no_transformation(self):
+        x_val = np.random.rand(100, 2, 2, 3)
+        x_val = np.array(x_val, dtype=np.float32)
+        x = tf.placeholder(tf.float32, shape=(None, 2, 2, 3))
+
+        x_adv_p = self.attack.generate(x, batch_size=100, dx_min=0.0,
+                                       dx_max=0.0, n_dxs=1, dy_min=0.0,
+                                       dy_max=0.0, n_dys=1, angle_min=0,
+                                       angle_max=0, n_angles=1)
+        x_adv = self.sess.run(x_adv_p, {x: x_val})
+        self.assertClose(x_adv, x_val)
+
+    def test_attack_strength(self):
+        x_val = np.random.rand(100, 2, 2, 3)
+        x_val = np.array(x_val, dtype=np.float32)
+        ttt = self.sess.run(self.model(x_val))
+        orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
+        x = tf.placeholder(tf.float32, shape=(None, 2, 2, 3))
+
+        x_adv_p = self.attack.generate(x, batch_size=100, dx_min=-0.2,
+                                       dx_max=0.2, n_dxs=3, dy_min=-0.2,
+                                       dy_max=0.2, n_dys=3, angle_min=-45,
+                                       angle_max=45, n_angles=3)
+        x_adv = self.sess.run(x_adv_p, {x: x_val})
+        new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
+        self.assertTrue(np.mean(orig_labs == new_labs) < 0.7)
+        print(np.mean(orig_labs == new_labs) )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request implements the spatial transformation-based attack proposed in [1], addressing #490 . 

Here is the procedure of the attack:
1. randomly sample `n_samples` set of different translation & rotation parameters
2. apply the transformations to the testing set and choose the worst of `n_samples` transformation as the attack

A notebook demo of the attack can be found [here](http://nbviewer.jupyter.org/github/yenchenlin/cleverhans/blob/transformation-attack/cleverhans_tutorials/mnist_tutorial_tran.ipynb), where the testing accuracy of the classifier drops from **98.74%** to **59.61%** (Results in [1]: **99.31%** to **73.32%**)

[1] A Rotation and a Translation Suffice: Fooling CNNs with Simple Transformations, Engstorm et al.