### PR TITLE
Add BasicIterativeMethod in eager execution

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -431,11 +431,14 @@ class BasicIterativeMethod(Attack):
         }
 
         if not tf.executing_eagerly():
-            FGM = FastGradientMethod(self.model, back=self.back, sess=self.sess, dtypestr=self.dtypestr)
+            FGM = FastGradientMethod(
+                self.model, back=self.back,
+                sess=self.sess, dtypestr=self.dtypestr)
         else:
             # eager execution
             import cleverhans.attacks_tfe as attacks_tfe
-            FGM = attacks_tfe.FastGradientMethod(self.model, dtypestr=self.dtypestr)
+            FGM = attacks_tfe.FastGradientMethod(
+                self.model, dtypestr=self.dtypestr)
 
         def cond(i, _):
             return tf.less(i, self.nb_iter)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -430,7 +430,12 @@ class BasicIterativeMethod(Attack):
             'clip_max': self.clip_max
         }
 
-        if not tf.executing_eagerly():
+        try:
+            eager_executing = tf.executing_eagerly()
+        except:
+            eager_executing = False
+
+        if eager_executing:
             FGM = FastGradientMethod(
                 self.model, back=self.back,
                 sess=self.sess, dtypestr=self.dtypestr)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -49,6 +49,7 @@ class Attack(object):
         self.model = model
         self.back = back
         self.sess = sess
+        self.dtypestr = dtypestr
 
         # We are going to keep track of old graphs and cache them.
         self.graphs = {}
@@ -429,7 +430,12 @@ class BasicIterativeMethod(Attack):
             'clip_max': self.clip_max
         }
 
-        FGM = FastGradientMethod(self.model, back=self.back, sess=self.sess)
+        if not tf.executing_eagerly():
+            FGM = FastGradientMethod(self.model, back=self.back, sess=self.sess, dtypestr=self.dtypestr)
+        else:
+            # eager execution
+            import cleverhans.attacks_tfe as attacks_tfe
+            FGM = attacks_tfe.FastGradientMethod(self.model, dtypestr=self.dtypestr)
 
         def cond(i, _):
             return tf.less(i, self.nb_iter)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -435,7 +435,7 @@ class BasicIterativeMethod(Attack):
         except:
             eager_executing = False
 
-        if eager_executing:
+        if not eager_executing:
             FGM = FastGradientMethod(
                 self.model, back=self.back,
                 sess=self.sess, dtypestr=self.dtypestr)

--- a/cleverhans/attacks_tfe.py
+++ b/cleverhans/attacks_tfe.py
@@ -5,15 +5,13 @@ import warnings
 import collections
 import tensorflow as tf
 
-from distutils.version import LooseVersion
+import cleverhans.attacks as attacks
 import cleverhans.utils as utils
-from cleverhans.attacks import Attack
-from cleverhans.attacks import BasicIterativeMethod
-from cleverhans.attacks import FastGradientMethod
 from cleverhans.compat import reduce_max
 from cleverhans.compat import reduce_sum
 from cleverhans.model import Model
 from cleverhans.loss import LossCrossEntropy
+from distutils.version import LooseVersion
 
 _logger = utils.create_logger("cleverhans.attacks_tfe")
 
@@ -24,7 +22,7 @@ if LooseVersion(tf.__version__) < LooseVersion('1.8.0'):
     raise ValueError(error)
 
 
-class AttackTFE(Attack):
+class Attack(attacks.Attack):
     """
     Abstract base class for all eager attack classes.
     """
@@ -83,9 +81,9 @@ class AttackTFE(Attack):
         raise AttributeError(error)
 
 
-class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
+class FastGradientMethod(Attack, attacks.FastGradientMethod):
     """
-    Inherited class from AttackTFE and FastGradientMethod.
+    Inherited class from Attack and cleverhans.attacks.FastGradientMethod.
 
     This attack was originally implemented by Goodfellow et al. (2015) with the
     infinity norm (and is known as the "Fast Gradient Sign Method"). This
@@ -96,7 +94,7 @@ class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
 
     def __init__(self, model, dtypestr='float32'):
         """
-        Creates a FastGradientMethodTFE instance.
+        Creates a FastGradientMethod instance in eager execution.
         :model: CNN network, should be an instance of
                 cleverhans.model.Model, if not wrap
                 the output to probs.
@@ -105,12 +103,11 @@ class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(FastGradientMethodTFE, self).__init__(model, dtypestr)
+        super(FastGradientMethod, self).__init__(model, dtypestr)
 
     def generate(self, x, **kwargs):
         """
         Generates the adversarial sample for the given input.
-
         :param x: The model's inputs.
         :param eps: (optional float) attack step size (input variation)
         :param ord: (optional) Order of the norm (mimics NumPy).
@@ -196,9 +193,9 @@ class FastGradientMethodTFE(AttackTFE, FastGradientMethod):
         return adv_x
 
 
-class BasicIterativeMethodTFE(AttackTFE, BasicIterativeMethod):
+class BasicIterativeMethod(Attack, attacks.BasicIterativeMethod):
     """
-    Inherited class from AttackTFE and BasicIterativeMethod.
+    Inherited class from Attack and cleverhans.attacks.BasicIterativeMethod.
 
     The Basic Iterative Method (Kurakin et al. 2016). The original paper used
     hard labels for this attack; no label smoothing.
@@ -207,7 +204,7 @@ class BasicIterativeMethodTFE(AttackTFE, BasicIterativeMethod):
 
     def __init__(self, model, dtypestr='float32'):
         """
-        Creates a BasicIterativeMethodTFE instance.
+        Creates a BasicIterativeMethod instance in eager execution.
         :model: CNN network, should be an instance of
                 cleverhans.model.Model, if not wrap
                 the output to probs.
@@ -216,78 +213,4 @@ class BasicIterativeMethodTFE(AttackTFE, BasicIterativeMethod):
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
-        super(BasicIterativeMethodTFE, self).__init__(model, dtypestr)
-
-    def generate(self, x, **kwargs):
-        """
-        Generates the adversarial sample for the given input.
-
-        :param x: The model's symbolic inputs.
-        :param eps: (required float) maximum distortion of adversarial example
-                    compared to original input
-        :param eps_iter: (required float) step size for each attack iteration
-        :param nb_iter: (required int) Number of attack iterations.
-        :param y: (optional) A tensor with the model labels.
-        :param y_target: (optional) A tensor with the labels to target. Leave
-                         y_target=None if y is also set. Labels should be
-                         one-hot-encoded.
-        :param ord: (optional) Order of the norm (mimics Numpy).
-                    Possible values: np.inf, 1 or 2.
-        :param clip_min: (optional float) Minimum input component value
-        :param clip_max: (optional float) Maximum input component value
-        """
-        # Parse and save attack-specific parameters
-        assert self.parse_params(**kwargs)
-
-        # Initialize loop variables
-        eta = tf.zeros_like(x)
-
-        # Fix labels to the first model predictions for loss computation
-        model_preds = self.model.get_probs(x)
-        preds_max = reduce_max(model_preds, 1, keepdims=True)
-        if self.y_target is not None:
-            y = self.y_target
-            targeted = True
-        elif self.y is not None:
-            y = self.y
-            targeted = False
-        else:
-            y = tf.to_float(tf.equal(model_preds, preds_max))
-            y = tf.stop_gradient(y)
-            targeted = False
-
-        y_kwarg = 'y_target' if targeted else 'y'
-        fgm_params = {
-            'eps': self.eps_iter,
-            y_kwarg: y,
-            'ord': self.ord,
-            'clip_min': self.clip_min,
-            'clip_max': self.clip_max
-        }
-
-        FGM = FastGradientMethodTFE(self.model, dtypestr=self.dtypestr)
-
-        def cond(i, _):
-            return tf.less(i, self.nb_iter)
-
-        def body(i, e):
-            adv_x = FGM.generate(x + e, **fgm_params)
-
-            # Clipping perturbation according to clip_min and clip_max
-            if self.clip_min is not None and self.clip_max is not None:
-                adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
-
-            # Clipping perturbation eta to self.ord norm ball
-            eta = adv_x - x
-            from cleverhans.utils_tf import clip_eta
-            eta = clip_eta(eta, self.ord, self.eps)
-            return i + 1, eta
-
-        _, eta = tf.while_loop(cond, body, [tf.zeros([]), eta], back_prop=True)
-
-        # Define adversarial example (and clip if necessary)
-        adv_x = x + eta
-        if self.clip_min is not None and self.clip_max is not None:
-            adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
-
-        return adv_x
+        super(BasicIterativeMethod, self).__init__(model, dtypestr)

--- a/cleverhans/attacks_tfe.py
+++ b/cleverhans/attacks_tfe.py
@@ -92,7 +92,7 @@ class FastGradientMethod(Attack, attacks.FastGradientMethod):
     Paper link: https://arxiv.org/abs/1412.6572
     """
 
-    def __init__(self, model, dtypestr='float32'):
+    def __init__(self, model, dtypestr='float32', **kwargs):
         """
         Creates a FastGradientMethod instance in eager execution.
         :model: CNN network, should be an instance of
@@ -100,6 +100,7 @@ class FastGradientMethod(Attack, attacks.FastGradientMethod):
                 the output to probs.
         :dtypestr: datatype in the string format.
         """
+        del kwargs
         if not isinstance(model, Model):
             model = CallableModelWrapper(model, 'probs')
 
@@ -201,6 +202,8 @@ class BasicIterativeMethod(Attack, attacks.BasicIterativeMethod):
     hard labels for this attack; no label smoothing.
     Paper link: https://arxiv.org/pdf/1607.02533.pdf
     """
+
+    FGM_CLASS = FastGradientMethod
 
     def __init__(self, model, dtypestr='float32'):
         """

--- a/cleverhans_tutorials/mnist_tutorial_tfe.py
+++ b/cleverhans_tutorials/mnist_tutorial_tfe.py
@@ -32,8 +32,8 @@ except AttributeError:
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils import AccuracyReport, set_log_level
 from cleverhans.utils_tfe import train, model_eval
-from cleverhans.attacks_tfe import BasicIterativeMethodTFE
-from cleverhans.attacks_tfe import FastGradientMethodTFE
+from cleverhans.attacks_tfe import BasicIterativeMethod
+from cleverhans.attacks_tfe import FastGradientMethod
 from cleverhans_tutorials.tutorial_models_tfe import ModelBasicCNNTFE
 
 if tf.executing_eagerly() is True:
@@ -48,10 +48,11 @@ FLAGS = flags.FLAGS
 # Keeps track of implemented attacks.
 # Maps attack string taken from bash to attack class
 # -- 'fgsm' : FastGradientMethod
+# -- 'bim': BasicIterativeMethod
 
 AVAILABLE_ATTACKS = {
-    'fgsm': FastGradientMethodTFE,
-    'bim': BasicIterativeMethodTFE
+    'fgsm': FastGradientMethod,
+    'bim': BasicIterativeMethod
 }
 
 

--- a/cleverhans_tutorials/mnist_tutorial_tfe.py
+++ b/cleverhans_tutorials/mnist_tutorial_tfe.py
@@ -32,6 +32,7 @@ except AttributeError:
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils import AccuracyReport, set_log_level
 from cleverhans.utils_tfe import train, model_eval
+from cleverhans.attacks_tfe import BasicIterativeMethodTFE
 from cleverhans.attacks_tfe import FastGradientMethodTFE
 from cleverhans_tutorials.tutorial_models_tfe import ModelBasicCNNTFE
 
@@ -49,12 +50,12 @@ FLAGS = flags.FLAGS
 # -- 'fgsm' : FastGradientMethod
 
 AVAILABLE_ATTACKS = {
-                     'fgsm': FastGradientMethodTFE
-                    }
+    'fgsm': FastGradientMethodTFE,
+    'bim': BasicIterativeMethodTFE
+}
 
 
 def attack_selection(attack_string):
-
     """
     Selects the Attack Class using string input.
     :param attack_string: adversarial attack name in string format


### PR DESCRIPTION
This PR adds basic iterative method in Tensorflow eager mode, and mainly modifies the following two parts:

1. Gradient tape in [this line](https://github.com/tensorflow/cleverhans/compare/master...WindQAQ:master#diff-1e01328cea7defb5113accf896de8718R146) should watch at `x` so that the `tape.gradient(loss, x)` can be calculated. Original `FastGradientMethodTFE` works without any error because the input `x` is created by `tfe.Variable` ([here](https://github.com/tensorflow/cleverhans/blob/master/cleverhans/utils_tfe.py#L70)), which is automatically watched by gradient tape ([ref](https://www.tensorflow.org/api_docs/python/tf/GradientTape)).

2. Add `BasicIterativeMethodTFE` and add it into available attacks in `cleverhans_tutorial/mnist_tutorial_tfe.py`.