### PR TITLE
Dataset class

### DIFF
--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -16,7 +16,7 @@ class Dataset(object):
     """
 
     # The number of classes in the dataset. Should be specified by subclasses.
-    nb_classes = None
+    NB_CLASSES = None
 
     def get_factory(self):
         """Returns a picklable callable that recreates the dataset.
@@ -38,7 +38,7 @@ class Dataset(object):
 class MNIST(Dataset):
     """The MNIST dataset"""
 
-    nb_classes = 10
+    NB_CLASSES = 10
 
     def __init__(self, train_start=0, train_end=60000, test_start=0,
                  test_end=10000, center=False):
@@ -62,7 +62,7 @@ class MNIST(Dataset):
 class CIFAR10(Dataset):
     """The CIFAR-10 dataset"""
 
-    nb_classes = 10
+    NB_CLASSES = 10
 
     def __init__(self, train_start=0, train_end=60000, test_start=0,
                  test_end=10000, center=False):

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -56,6 +56,29 @@ class MNIST(Dataset):
         self.x_test = x_test
         self.y_test = y_test
 
+class CIFAR10(Dataset):
+  """The CIFAR-10 dataset"""
+
+  nb_classes = 10
+
+    def __init__(self, train_start=0, train_end=60000, test_start=0,
+                 test_end=10000, center=False):
+        self.kwargs = locals()
+        del self.kwargs["self"]
+        x_train, y_train, x_test, y_test = data_cifar10(train_start=train_start,
+                                                      train_end=train_end,
+                                                      test_start=test_start,
+                                                      test_end=test_end)
+
+        if center:
+            x_train = x_train * 2. - 1.
+            x_test = x_test * 2. - 1.
+
+        self.x_train = x_train
+        self.y_train = y_train
+        self.x_test = x_test
+        self.y_test = y_test
+
 
 class Factory(object):
     """
@@ -71,3 +94,36 @@ class Factory(object):
         """Returns the created object.
         """
         return self.cls(*self.args, **self.kwargs)
+
+def data_cifar10():
+    """
+    Preprocess CIFAR10 dataset
+    :return:
+    """
+
+    # These values are specific to CIFAR10
+    img_rows = 32
+    img_cols = 32
+    nb_classes = 10
+
+    # the data, shuffled and split between train and test sets
+    (X_train, y_train), (X_test, y_test) = cifar10.load_data()
+
+    if keras.backend.image_dim_ordering() == 'th':
+        X_train = X_train.reshape(X_train.shape[0], 3, img_rows, img_cols)
+        X_test = X_test.reshape(X_test.shape[0], 3, img_rows, img_cols)
+    else:
+        X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 3)
+        X_test = X_test.reshape(X_test.shape[0], img_rows, img_cols, 3)
+    X_train = X_train.astype('float32')
+    X_test = X_test.astype('float32')
+    X_train /= 255
+    X_test /= 255
+    print('X_train shape:', X_train.shape)
+    print(X_train.shape[0], 'train samples')
+    print(X_test.shape[0], 'test samples')
+
+    # convert class vectors to binary class matrices
+    Y_train = np_utils.to_categorical(y_train, nb_classes)
+    Y_test = np_utils.to_categorical(y_test, nb_classes)
+    return X_train, Y_train, X_test, Y_test

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -82,8 +82,7 @@ class Factory(object):
     A callable that creates an object of the specified type and configuration.
     """
 
-    def __init__(self, cls, args, kwargs):
-        self.cls = cls
+    def __init__(self, cls, kwargs):
         self.kwargs = kwargs
 
     def __call__(self):

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 
 from cleverhans.utils_mnist import data_mnist
 
-keras = None # Only load keras if user tries to use a dataset that requires it
+keras = None  # Only load keras if user tries to use a dataset that requires it
 
 
 class Dataset(object):
@@ -58,6 +58,7 @@ class MNIST(Dataset):
         self.x_test = x_test
         self.y_test = y_test
 
+
 class CIFAR10(Dataset):
     """The CIFAR-10 dataset"""
 
@@ -67,10 +68,11 @@ class CIFAR10(Dataset):
                  test_end=10000, center=False):
         self.kwargs = locals()
         del self.kwargs["self"]
-        x_train, y_train, x_test, y_test = data_cifar10(train_start=train_start,
-                                                      train_end=train_end,
-                                                      test_start=test_start,
-                                                      test_end=test_end)
+        packed = data_cifar10(train_start=train_start,
+                              train_end=train_end,
+                              test_start=test_start,
+                              test_end=test_end)
+        x_train, y_train, x_test, y_test = packed
 
         if center:
             x_train = x_train * 2. - 1.
@@ -97,6 +99,7 @@ class Factory(object):
         """
         return self.cls(*self.args, **self.kwargs)
 
+
 def data_cifar10(train_start=0, train_end=50000, test_start=0, test_end=10000):
     """
     Preprocess CIFAR10 dataset
@@ -105,8 +108,9 @@ def data_cifar10(train_start=0, train_end=50000, test_start=0, test_end=10000):
 
     global keras
     if keras is None:
-      import keras
-      from keras.datasets import cifar10
+        import keras
+        from keras.datasets import cifar10
+        from keras.utils import np_utils
 
     # These values are specific to CIFAR10
     img_rows = 32

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -27,12 +27,7 @@ class Dataset(object):
         """Returns a picklable callable that recreates the dataset.
         """
 
-        if hasattr(self, 'kwargs'):
-            kwargs = self.kwargs
-        else:
-            kwargs = {}
-
-        return Factory(type(self), kwargs)
+        return Factory(type(self), self.kwargs)
 
 
 class MNIST(Dataset):

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -43,7 +43,6 @@ class MNIST(Dataset):
     def __init__(self, train_start=0, train_end=60000, test_start=0,
                  test_end=10000, center=False):
         super(MNIST, self).__init__(**locals())
-        self.kwargs = locals()
         x_train, y_train, x_test, y_test = data_mnist(train_start=train_start,
                                                       train_end=train_end,
                                                       test_start=test_start,

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -57,9 +57,9 @@ class MNIST(Dataset):
         self.y_test = y_test
 
 class CIFAR10(Dataset):
-  """The CIFAR-10 dataset"""
+    """The CIFAR-10 dataset"""
 
-  nb_classes = 10
+    nb_classes = 10
 
     def __init__(self, train_start=0, train_end=60000, test_start=0,
                  test_end=10000, center=False):

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -1,0 +1,73 @@
+"""Dataset class for CleverHans
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from cleverhans.utils_mnist import data_mnist
+
+
+class Dataset(object):
+    """Abstract base class representing a dataset.
+    """
+
+    # The number of classes in the dataset. Should be specified by subclasses.
+    nb_classes = None
+
+    def get_factory(self):
+        """Returns a picklable callable that recreates the dataset.
+        """
+
+        if hasattr(self, 'args'):
+            args = self.args
+        else:
+            args = []
+
+        if hasattr(self, 'kwargs'):
+            kwargs = self.kwargs
+        else:
+            kwargs = {}
+
+        return Factory(type(self), args, kwargs)
+
+
+class MNIST(Dataset):
+    """The MNIST dataset"""
+
+    nb_classes = 10
+
+    def __init__(self, train_start=0, train_end=60000, test_start=0,
+                 test_end=10000, center=False):
+        self.kwargs = locals()
+        del self.kwargs["self"]
+        x_train, y_train, x_test, y_test = data_mnist(train_start=train_start,
+                                                      train_end=train_end,
+                                                      test_start=test_start,
+                                                      test_end=test_end)
+
+        if center:
+            x_train = x_train * 2. - 1.
+            x_test = x_test * 2. - 1.
+
+        self.x_train = x_train
+        self.y_train = y_train
+        self.x_test = x_test
+        self.y_test = y_test
+
+
+class Factory(object):
+    """
+    A callable that creates an object of the specified type and configuration.
+    """
+
+    def __init__(self, cls, args, kwargs):
+        self.cls = cls
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self):
+        """Returns the created object.
+        """
+        return self.cls(*self.args, **self.kwargs)

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -18,21 +18,21 @@ class Dataset(object):
     # The number of classes in the dataset. Should be specified by subclasses.
     NB_CLASSES = None
 
+    def __init__(self, **kwargs):
+        if "self" in kwargs:
+          del kwargs[self]
+        self.kwargs = kwargs
+
     def get_factory(self):
         """Returns a picklable callable that recreates the dataset.
         """
-
-        if hasattr(self, 'args'):
-            args = self.args
-        else:
-            args = []
 
         if hasattr(self, 'kwargs'):
             kwargs = self.kwargs
         else:
             kwargs = {}
 
-        return Factory(type(self), args, kwargs)
+        return Factory(type(self), kwargs)
 
 
 class MNIST(Dataset):
@@ -42,8 +42,8 @@ class MNIST(Dataset):
 
     def __init__(self, train_start=0, train_end=60000, test_start=0,
                  test_end=10000, center=False):
+        super(MNIST, self).__init__(**locals())
         self.kwargs = locals()
-        del self.kwargs["self"]
         x_train, y_train, x_test, y_test = data_mnist(train_start=train_start,
                                                       train_end=train_end,
                                                       test_start=test_start,
@@ -66,8 +66,7 @@ class CIFAR10(Dataset):
 
     def __init__(self, train_start=0, train_end=60000, test_start=0,
                  test_end=10000, center=False):
-        self.kwargs = locals()
-        del self.kwargs["self"]
+        super(CIFAR10, self).__init__(**locals())
         packed = data_cifar10(train_start=train_start,
                               train_end=train_end,
                               test_start=test_start,
@@ -91,13 +90,12 @@ class Factory(object):
 
     def __init__(self, cls, args, kwargs):
         self.cls = cls
-        self.args = args
         self.kwargs = kwargs
 
     def __call__(self):
         """Returns the created object.
         """
-        return self.cls(*self.args, **self.kwargs)
+        return self.cls(**self.kwargs)
 
 
 def data_cifar10(train_start=0, train_end=50000, test_start=0, test_end=10000):
@@ -118,29 +116,29 @@ def data_cifar10(train_start=0, train_end=50000, test_start=0, test_end=10000):
     nb_classes = 10
 
     # the data, shuffled and split between train and test sets
-    (X_train, y_train), (X_test, y_test) = cifar10.load_data()
+    (x_train, y_train), (x_test, y_test) = cifar10.load_data()
 
     if keras.backend.image_dim_ordering() == 'th':
-        X_train = X_train.reshape(X_train.shape[0], 3, img_rows, img_cols)
-        X_test = X_test.reshape(X_test.shape[0], 3, img_rows, img_cols)
+        x_train = x_train.reshape(x_train.shape[0], 3, img_rows, img_cols)
+        x_test = x_test.reshape(x_test.shape[0], 3, img_rows, img_cols)
     else:
-        X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 3)
-        X_test = X_test.reshape(X_test.shape[0], img_rows, img_cols, 3)
-    X_train = X_train.astype('float32')
-    X_test = X_test.astype('float32')
-    X_train /= 255
-    X_test /= 255
-    print('X_train shape:', X_train.shape)
-    print(X_train.shape[0], 'train samples')
-    print(X_test.shape[0], 'test samples')
+        x_train = x_train.reshape(x_train.shape[0], img_rows, img_cols, 3)
+        x_test = x_test.reshape(x_test.shape[0], img_rows, img_cols, 3)
+    x_train = x_train.astype('float32')
+    x_test = x_test.astype('float32')
+    x_train /= 255
+    x_test /= 255
+    print('x_train shape:', x_train.shape)
+    print(x_train.shape[0], 'train samples')
+    print(x_test.shape[0], 'test samples')
 
     # convert class vectors to binary class matrices
-    Y_train = np_utils.to_categorical(y_train, nb_classes)
-    Y_test = np_utils.to_categorical(y_test, nb_classes)
+    y_train = np_utils.to_categorical(y_train, nb_classes)
+    y_test = np_utils.to_categorical(y_test, nb_classes)
 
-    X_train = X_train[train_start:train_end, :, :, :]
-    Y_train = Y_train[train_start:train_end, :]
-    X_test = X_test[test_start:test_end, :]
-    Y_test = Y_test[test_start:test_end, :]
+    x_train = x_train[train_start:train_end, :, :, :]
+    y_train = y_train[train_start:train_end, :]
+    x_test = x_test[test_start:test_end, :]
+    y_test = y_test[test_start:test_end, :]
 
-    return X_train, Y_train, X_test, Y_test
+    return x_train, y_train, x_test, y_test

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -20,7 +20,7 @@ class Dataset(object):
 
     def __init__(self, **kwargs):
         if "self" in kwargs:
-          del kwargs[self]
+            del kwargs[self]
         self.kwargs = kwargs
 
     def get_factory(self):

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -95,7 +95,7 @@ class Factory(object):
         """
         return self.cls(*self.args, **self.kwargs)
 
-def data_cifar10():
+def data_cifar10(train_start=0, train_end=50000, test_start=0, test_end=10000):
     """
     Preprocess CIFAR10 dataset
     :return:
@@ -126,4 +126,10 @@ def data_cifar10():
     # convert class vectors to binary class matrices
     Y_train = np_utils.to_categorical(y_train, nb_classes)
     Y_test = np_utils.to_categorical(y_test, nb_classes)
+
+    X_train = X_train[train_start:train_end, :, :, :]
+    Y_train = Y_train[train_start:train_end, :]
+    X_test = X_test[test_start:test_end, :]
+    Y_test = Y_test[test_start:test_end, :]
+
     return X_train, Y_train, X_test, Y_test

--- a/cleverhans/dataset.py
+++ b/cleverhans/dataset.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 
 from cleverhans.utils_mnist import data_mnist
 
+keras = None # Only load keras if user tries to use a dataset that requires it
+
 
 class Dataset(object):
     """Abstract base class representing a dataset.
@@ -100,6 +102,11 @@ def data_cifar10(train_start=0, train_end=50000, test_start=0, test_end=10000):
     Preprocess CIFAR10 dataset
     :return:
     """
+
+    global keras
+    if keras is None:
+      import keras
+      from keras.datasets import cifar10
 
     # These values are specific to CIFAR10
     img_rows = 32

--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -27,8 +27,6 @@ flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
 flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
 
 
-
-
 def main(argv=None):
     """
     CIFAR10 CleverHans tutorial

--- a/examples/ex_cifar10_tf.py
+++ b/examples/ex_cifar10_tf.py
@@ -15,6 +15,7 @@ from tensorflow.python.platform import flags
 from cleverhans.attacks import FastGradientMethod
 from cleverhans.utils_keras import cnn_model
 from cleverhans.utils_tf import train, model_eval, batch_eval
+from cleverhans.dataset import data_cifar10
 
 FLAGS = flags.FLAGS
 
@@ -26,38 +27,6 @@ flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
 flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
 
 
-def data_cifar10():
-    """
-    Preprocess CIFAR10 dataset
-    :return:
-    """
-
-    # These values are specific to CIFAR10
-    img_rows = 32
-    img_cols = 32
-    nb_classes = 10
-
-    # the data, shuffled and split between train and test sets
-    (X_train, y_train), (X_test, y_test) = cifar10.load_data()
-
-    if keras.backend.image_dim_ordering() == 'th':
-        X_train = X_train.reshape(X_train.shape[0], 3, img_rows, img_cols)
-        X_test = X_test.reshape(X_test.shape[0], 3, img_rows, img_cols)
-    else:
-        X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 3)
-        X_test = X_test.reshape(X_test.shape[0], img_rows, img_cols, 3)
-    X_train = X_train.astype('float32')
-    X_test = X_test.astype('float32')
-    X_train /= 255
-    X_test /= 255
-    print('X_train shape:', X_train.shape)
-    print(X_train.shape[0], 'train samples')
-    print(X_test.shape[0], 'test samples')
-
-    # convert class vectors to binary class matrices
-    Y_train = np_utils.to_categorical(y_train, nb_classes)
-    Y_test = np_utils.to_categorical(y_test, nb_classes)
-    return X_train, Y_train, X_test, Y_test
 
 
 def main(argv=None):


### PR DESCRIPTION
This Dataset class is intended to pave the way for generic evaluation scripts. A single script can be pointed at a pickled model. The script can then read a pickled Factory out of the model and reconstruct the same dataset that was used to train the model. This way we can write one script that evaluates a wide range of models on a wide range of datasets, rather than needing to write many scripts that are hard-coded to each (model, dataset) combination.