### PR TITLE
use mean value for loss

### DIFF
--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -79,7 +79,8 @@ class LossCrossEntropy(Loss):
 
         logits = [self.model.get_logits(x, **kwargs) for x in x]
         loss = sum(
-            softmax_cross_entropy_with_logits(labels=y, logits=logit)
+            tf.reduce_mean(softmax_cross_entropy_with_logits(labels=y,
+                logits=logit))
             for logit in logits)
         return loss
 

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -32,6 +32,11 @@ class Loss(object):
 
     def fprop(self, x, y):
         """Forward propagate the loss.
+        Loss should be a scalar value, independent of batch size (i.e. use
+        reduce_mean over batch axis, don't use reduce_sum or return a tensor).
+        Scalar losses are easier to add together, e.g. through `WeightedSum`.
+        Mean losses are easier to redistribute across multiple replicas without
+        needing to change learning rates, etc.
         :param x: tensor, a batch of inputs.
         :param y: tensor, a batch of outputs (1-hot labels typically).
         """

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -124,10 +124,10 @@ class LossFeaturePairing(Loss):
                         for a, b in
                         zip(d1[Model.O_FEATURES], d2[Model.O_FEATURES])]
         pairing_loss = tf.reduce_mean(pairing_loss)
-        loss = softmax_cross_entropy_with_logits(
-            labels=y, logits=d1[Model.O_LOGITS])
-        loss += softmax_cross_entropy_with_logits(
-            labels=y, logits=d2[Model.O_LOGITS])
+        loss = tf.reduce_mean(softmax_cross_entropy_with_logits(
+            labels=y, logits=d1[Model.O_LOGITS]))
+        loss += tf.reduce_mean(softmax_cross_entropy_with_logits(
+            labels=y, logits=d2[Model.O_LOGITS]))
         return loss + self.weight * pairing_loss
 
 

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -107,7 +107,7 @@ class MixUp(Loss):
         ym = y + mix * (y[::-1] - y)
         logits = self.model.get_logits(xm, **kwargs)
         loss = tf.reduce_mean(softmax_cross_entropy_with_logits(labels=ym,
-            logits=logits))
+                                                                logits=logits))
         return loss
 
 
@@ -160,11 +160,13 @@ def attack_softmax_cross_entropy(y, probs, mean=True):
     out = softmax_cross_entropy_with_logits(logits=logits, labels=y)
     return tf.reduce_mean(out) if mean else out
 
+
 class LossCrossEntropy(Loss):
     """
     Deprecated version of `CrossEntropy` that returns per-example loss rather
     than mean loss.
     """
+
     def __init__(self, model, smoothing=0., attack=None, **kwargs):
         """Constructor.
         :param model: Model instance, the model on which to apply the loss.
@@ -193,12 +195,13 @@ class LossCrossEntropy(Loss):
         logits = [self.model.get_logits(x, **kwargs) for x in x]
         loss = sum(
             softmax_cross_entropy_with_logits(labels=y,
-                                                             logits=logit)
+                                              logits=logit)
             for logit in logits)
         warnings.warn("LossCrossEntropy is deprecated, switch to "
                       "CrossEntropy. LossCrossEntropy may be removed on "
                       "or after 2019-03-06.")
         return loss
+
 
 class LossFeaturePairing(Loss):
     """Deprecated version of `FeaturePairing` that returns per-example loss
@@ -231,9 +234,11 @@ class LossFeaturePairing(Loss):
                       "on or after 2019-03-06.")
         return loss + self.weight * pairing_loss
 
+
 class LossMixUp(Loss):
     """Deprecated version of `MixUp` that returns per-example loss
     rather than mean loss."""
+
     def __init__(self, model, beta, **kwargs):
         """Constructor.
         :param model: Model instance, the model on which to apply the loss.

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -80,7 +80,7 @@ class LossCrossEntropy(Loss):
         logits = [self.model.get_logits(x, **kwargs) for x in x]
         loss = sum(
             tf.reduce_mean(softmax_cross_entropy_with_logits(labels=y,
-                logits=logit))
+                                                             logits=logit))
             for logit in logits)
         return loss
 

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -56,6 +56,7 @@ class WeightedSum(Loss):
 
         return tf.add_n(terms)
 
+
 class CrossEntropy(Loss):
     def __init__(self, model, smoothing=0., attack=None, **kwargs):
         """Constructor.

--- a/cleverhans_tutorials/evaluate_pickled_model.py
+++ b/cleverhans_tutorials/evaluate_pickled_model.py
@@ -12,7 +12,7 @@ import tensorflow as tf
 from tensorflow.python.platform import flags
 import logging
 
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils_tf import train, model_eval
 from cleverhans.attacks import FastGradientMethod

--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -18,7 +18,7 @@ import logging
 import tensorflow as tf
 from tensorflow.python.platform import flags
 
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.model import Model
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils import to_categorical
@@ -69,7 +69,7 @@ def prep_bbox(sess, x, y, X_train, Y_train, X_test, Y_test,
     # Define TF model graph (for the black-box model)
     nb_filters = 64
     model = ModelBasicCNN('model1', nb_classes, nb_filters)
-    loss = LossCrossEntropy(model, smoothing=0.1)
+    loss = CrossEntropy(model, smoothing=0.1)
     predictions = model.get_logits(x)
     print("Defined TensorFlow model graph.")
 
@@ -135,7 +135,7 @@ def train_sub(sess, x, y, bbox_preds, X_sub, Y_sub, nb_classes,
     # Define TF model graph (for the black-box model)
     model_sub = ModelSubstitute('model_s', nb_classes)
     preds_sub = model_sub.get_logits(x)
-    loss_sub = LossCrossEntropy(model_sub, smoothing=0)
+    loss_sub = CrossEntropy(model_sub, smoothing=0)
 
     print("Defined TensorFlow model graph for the substitute.")
 

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -239,7 +239,8 @@ if __name__ == '__main__':
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
     flags.DEFINE_integer('source_samples', 10, 'Nb of test inputs to attack')
-    flags.DEFINE_float('learning_rate', LEARNING_RATE, 'Learning rate for training')
+    flags.DEFINE_float('learning_rate', LEARNING_RATE,
+                       'Learning rate for training')
     flags.DEFINE_string('model_path', os.path.join("models", "mnist"),
                         'Path to save or load the model file')
     flags.DEFINE_integer('attack_iterations', 100,

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -26,7 +26,7 @@ from cleverhans_tutorials.tutorial_models import ModelBasicCNN
 FLAGS = flags.FLAGS
 
 LEARNING_RATE = .001
-CW_LEARNING_RATE = .001
+CW_LEARNING_RATE = .1
 
 
 def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -16,7 +16,7 @@ from tensorflow.python.platform import flags
 import logging
 import os
 from cleverhans.attacks import CarliniWagnerL2
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils import grid_visual, AccuracyReport
 from cleverhans.utils import set_log_level
 from cleverhans.utils_mnist import data_mnist
@@ -79,7 +79,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     # Define TF model graph
     model = ModelBasicCNN('model1', nb_classes, nb_filters)
     preds = model.get_logits(x)
-    loss = LossCrossEntropy(model, smoothing=0.1)
+    loss = CrossEntropy(model, smoothing=0.1)
     print("Defined TensorFlow model graph.")
 
     ###########################################################################

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -26,13 +26,15 @@ from cleverhans_tutorials.tutorial_models import ModelBasicCNN
 FLAGS = flags.FLAGS
 
 LEARNING_RATE = .001
-CW_LEARNING_RATE = .1
+CW_LEARNING_RATE = .2
+ATTACK_ITERATIONS = 100
 
 
 def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                       test_end=10000, viz_enabled=True, nb_epochs=6,
                       batch_size=128, source_samples=10,
-                      learning_rate=LEARNING_RATE, attack_iterations=100,
+                      learning_rate=LEARNING_RATE,
+                      attack_iterations=ATTACK_ITERATIONS,
                       model_path=os.path.join("models", "mnist"),
                       targeted=True):
     """
@@ -243,7 +245,7 @@ if __name__ == '__main__':
                        'Learning rate for training')
     flags.DEFINE_string('model_path', os.path.join("models", "mnist"),
                         'Path to save or load the model file')
-    flags.DEFINE_integer('attack_iterations', 100,
+    flags.DEFINE_integer('attack_iterations', ATTACK_ITERATIONS,
                          'Number of iterations to run attack; 1000 is good')
     flags.DEFINE_boolean('targeted', True,
                          'Run the tutorial in targeted mode?')

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -16,7 +16,7 @@ from tensorflow.python.platform import flags
 import logging
 import os
 from cleverhans.attacks import CarliniWagnerL2
-from cleverhans.loss import CrossEntropy
+from cleverhans.loss import LossCrossEntropy as CrossEntropy
 from cleverhans.utils import grid_visual, AccuracyReport
 from cleverhans.utils import set_log_level
 from cleverhans.utils_mnist import data_mnist
@@ -25,11 +25,14 @@ from cleverhans_tutorials.tutorial_models import ModelBasicCNN
 
 FLAGS = flags.FLAGS
 
+LEARNING_RATE = .001
+CW_LEARNING_RATE = .001
+
 
 def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
                       test_end=10000, viz_enabled=True, nb_epochs=6,
                       batch_size=128, source_samples=10,
-                      learning_rate=0.001, attack_iterations=100,
+                      learning_rate=LEARNING_RATE, attack_iterations=100,
                       model_path=os.path.join("models", "mnist"),
                       targeted=True):
     """
@@ -165,7 +168,7 @@ def mnist_tutorial_cw(train_start=0, train_end=60000, test_start=0,
     cw_params = {'binary_search_steps': 1,
                  yname: adv_ys,
                  'max_iterations': attack_iterations,
-                 'learning_rate': 0.1,
+                 'learning_rate': CW_LEARNING_RATE,
                  'batch_size': source_samples * nb_classes if
                  targeted else source_samples,
                  'initial_const': 10}
@@ -236,7 +239,7 @@ if __name__ == '__main__':
     flags.DEFINE_integer('nb_epochs', 6, 'Number of epochs to train model')
     flags.DEFINE_integer('batch_size', 128, 'Size of training batches')
     flags.DEFINE_integer('source_samples', 10, 'Nb of test inputs to attack')
-    flags.DEFINE_float('learning_rate', 0.001, 'Learning rate for training')
+    flags.DEFINE_float('learning_rate', LEARNING_RATE, 'Learning rate for training')
     flags.DEFINE_string('model_path', os.path.join("models", "mnist"),
                         'Path to save or load the model file')
     flags.DEFINE_integer('attack_iterations', 100,

--- a/cleverhans_tutorials/mnist_tutorial_cw.py
+++ b/cleverhans_tutorials/mnist_tutorial_cw.py
@@ -16,7 +16,7 @@ from tensorflow.python.platform import flags
 import logging
 import os
 from cleverhans.attacks import CarliniWagnerL2
-from cleverhans.loss import LossCrossEntropy as CrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils import grid_visual, AccuracyReport
 from cleverhans.utils import set_log_level
 from cleverhans.utils_mnist import data_mnist

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -16,7 +16,7 @@ from tensorflow.python.platform import flags
 import logging
 
 from cleverhans.attacks import SaliencyMapMethod
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils import other_classes, set_log_level
 from cleverhans.utils import pair_visual, grid_visual, AccuracyReport
 from cleverhans.utils_mnist import data_mnist

--- a/cleverhans_tutorials/mnist_tutorial_jsma.py
+++ b/cleverhans_tutorials/mnist_tutorial_jsma.py
@@ -75,7 +75,7 @@ def mnist_tutorial_jsma(train_start=0, train_end=60000, test_start=0,
     # Define TF model graph
     model = ModelBasicCNN('model1', nb_classes, nb_filters)
     preds = model.get_logits(x)
-    loss = LossCrossEntropy(model, smoothing=0.1)
+    loss = CrossEntropy(model, smoothing=0.1)
     print("Defined TensorFlow model graph.")
 
     ###########################################################################

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from cleverhans.attacks import FastGradientMethod
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils import AccuracyReport
 from cleverhans.utils_keras import cnn_model
 from cleverhans.utils_keras import KerasModelWrapper
@@ -126,7 +126,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
         evaluate()
     else:
         print("Model was not loaded, training from scratch.")
-        loss = LossCrossEntropy(wrap, smoothing=label_smoothing)
+        loss = CrossEntropy(wrap, smoothing=label_smoothing)
         train(sess, loss, x, y, x_train, y_train, evaluate=evaluate,
               args=train_params, save=True, rng=rng)
 
@@ -172,7 +172,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
         return fgsm2.generate(x, **fgsm_params)
 
     preds_2_adv = model_2(attack(x))
-    loss_2 = LossCrossEntropy(wrap_2, smoothing=label_smoothing, attack=attack)
+    loss_2 = CrossEntropy(wrap_2, smoothing=label_smoothing, attack=attack)
 
     def evaluate_2():
         # Accuracy of adversarially trained model on legitimate test inputs

--- a/cleverhans_tutorials/mnist_tutorial_picklable.py
+++ b/cleverhans_tutorials/mnist_tutorial_picklable.py
@@ -12,7 +12,7 @@ import tensorflow as tf
 from tensorflow.python.platform import flags
 import logging
 
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils_tf import train, model_eval
 from cleverhans.attacks import FastGradientMethod
@@ -112,7 +112,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
         model = make_basic_picklable_cnn()
         preds = model.get_logits(x)
         assert len(model.get_params()) > 0
-        loss = LossCrossEntropy(model, smoothing=label_smoothing)
+        loss = CrossEntropy(model, smoothing=label_smoothing)
 
         def evaluate():
             do_eval(preds, x_test, y_test, 'clean_train_clean_eval', False)
@@ -153,7 +153,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     def attack(x):
         return fgsm2.generate(x, **fgsm_params)
 
-    loss2 = LossCrossEntropy(model2, smoothing=label_smoothing, attack=attack)
+    loss2 = CrossEntropy(model2, smoothing=label_smoothing, attack=attack)
     preds2 = model2.get_logits(x)
     adv_x2 = attack(x)
 

--- a/cleverhans_tutorials/mnist_tutorial_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_tf.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 from tensorflow.python.platform import flags
 import logging
 
-from cleverhans.loss import LossCrossEntropy
+from cleverhans.loss import CrossEntropy
 from cleverhans.utils_mnist import data_mnist
 from cleverhans.utils_tf import train, model_eval
 from cleverhans.attacks import FastGradientMethod
@@ -113,7 +113,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     if clean_train:
         model = ModelBasicCNN('model1', nb_classes, nb_filters)
         preds = model.get_logits(x)
-        loss = LossCrossEntropy(model, smoothing=label_smoothing)
+        loss = CrossEntropy(model, smoothing=label_smoothing)
 
         def evaluate():
             do_eval(preds, x_test, y_test, 'clean_train_clean_eval', False)
@@ -147,7 +147,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
     def attack(x):
         return fgsm2.generate(x, **fgsm_params)
 
-    loss2 = LossCrossEntropy(model2, smoothing=label_smoothing, attack=attack)
+    loss2 = CrossEntropy(model2, smoothing=label_smoothing, attack=attack)
     preds2 = model2.get_logits(x)
     adv_x2 = attack(x)
 

--- a/tests_tf/test_defenses.py
+++ b/tests_tf/test_defenses.py
@@ -51,8 +51,8 @@ class TestDefenses(CleverHansTest):
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
             vl2 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
-        self.assertClose(vl1, [2.210599660, 1.53666997], atol=1e-6)
-        self.assertClose(vl2, [2.210599660, 1.53666997], atol=1e-6)
+        self.assertClose(vl1, sum([2.210599660, 1.53666997]) / 2., atol=1e-6)
+        self.assertClose(vl2, sum([2.210599660, 1.53666997]) / 2., atol=1e-6)
 
     def test_xe_smoothing(self):
         loss = LossCrossEntropy(self.model, smoothing=0.1)
@@ -60,8 +60,8 @@ class TestDefenses(CleverHansTest):
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
             vl2 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
-        self.assertClose(vl1, [2.10587597, 1.47194624], atol=1e-6)
-        self.assertClose(vl2, [2.10587597, 1.47194624], atol=1e-6)
+        self.assertClose(vl1, sum([2.10587597, 1.47194624]) / 2., atol=1e-6)
+        self.assertClose(vl2, sum([2.10587597, 1.47194624]) / 2., atol=1e-6)
 
     def test_mixup(self):
         def eval_loss(l, count=1000):
@@ -88,16 +88,16 @@ class TestDefenses(CleverHansTest):
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
             vl2 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
-        self.assertClose(vl1, [4.296023369, 2.963884830], atol=1e-6)
-        self.assertClose(vl2, [4.296023369, 2.963884830], atol=1e-6)
+        self.assertClose(vl1, sum([4.296023369, 2.963884830]) / 2., atol=1e-6)
+        self.assertClose(vl2, sum([4.296023369, 2.963884830]) / 2., atol=1e-6)
 
         loss = LossFeaturePairing(self.model, weight=10., attack=attack)
         l = loss.fprop(self.x, self.y)
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
             vl2 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
-        self.assertClose(vl1, [4.333082676, 3.00094414], atol=1e-6)
-        self.assertClose(vl2, [4.333082676, 3.00094414], atol=1e-6)
+        self.assertClose(vl1, sum([4.333082676, 3.00094414]) / 2., atol=1e-6)
+        self.assertClose(vl2, sum([4.333082676, 3.00094414]) / 2., atol=1e-6)
 
 
 if __name__ == '__main__':

--- a/tests_tf/test_defenses.py
+++ b/tests_tf/test_defenses.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import unittest
 
 from cleverhans.attacks import FastGradientMethod
-from cleverhans.loss import LossCrossEntropy, LossMixUp, LossFeaturePairing
+from cleverhans.loss import CrossEntropy, MixUp, FeaturePairing
 from cleverhans.devtools.checks import CleverHansTest
 from cleverhans.model import Model
 import numpy as np
@@ -46,7 +46,7 @@ class TestDefenses(CleverHansTest):
         self.y = tf.placeholder(tf.float32, [None, 2], 'y')
 
     def test_xe(self):
-        loss = LossCrossEntropy(self.model, smoothing=0.)
+        loss = CrossEntropy(self.model, smoothing=0.)
         l = loss.fprop(self.x, self.y)
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
@@ -55,7 +55,7 @@ class TestDefenses(CleverHansTest):
         self.assertClose(vl2, sum([2.210599660, 1.53666997]) / 2., atol=1e-6)
 
     def test_xe_smoothing(self):
-        loss = LossCrossEntropy(self.model, smoothing=0.1)
+        loss = CrossEntropy(self.model, smoothing=0.1)
         l = loss.fprop(self.x, self.y)
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
@@ -72,18 +72,18 @@ class TestDefenses(CleverHansTest):
                                                  self.y: self.vy})
             return vl / count
 
-        loss = LossMixUp(self.model, beta=1.)
+        loss = MixUp(self.model, beta=1.)
         vl = eval_loss(loss.fprop(self.x, self.y))
         self.assertClose(vl, [1.23, 1.23], atol=5e-2)
 
-        loss = LossMixUp(self.model, beta=0.5)
+        loss = MixUp(self.model, beta=0.5)
         vl = eval_loss(loss.fprop(self.x, self.y))
         self.assertClose(vl, [1.40, 1.40], atol=5e-2)
 
     def test_feature_pairing(self):
         fgsm = FastGradientMethod(self.model)
         attack = lambda x: fgsm.generate(x)
-        loss = LossFeaturePairing(self.model, weight=0.1, attack=attack)
+        loss = FeaturePairing(self.model, weight=0.1, attack=attack)
         l = loss.fprop(self.x, self.y)
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})
@@ -91,7 +91,7 @@ class TestDefenses(CleverHansTest):
         self.assertClose(vl1, sum([4.296023369, 2.963884830]) / 2., atol=1e-6)
         self.assertClose(vl2, sum([4.296023369, 2.963884830]) / 2., atol=1e-6)
 
-        loss = LossFeaturePairing(self.model, weight=10., attack=attack)
+        loss = FeaturePairing(self.model, weight=10., attack=attack)
         l = loss.fprop(self.x, self.y)
         with tf.Session() as sess:
             vl1 = sess.run(l, feed_dict={self.x: self.vx, self.y: self.vy})

--- a/tests_tf/test_mnist_tutorial_cw.py
+++ b/tests_tf/test_mnist_tutorial_cw.py
@@ -21,12 +21,12 @@ class TestMNISTTutorialCW(CleverHansTest):
             report = mnist_tutorial_cw.mnist_tutorial_cw(**cw_tutorial_args)
 
         # Check accuracy values contained in the AccuracyReport object
-        self.assertTrue(report.clean_train_clean_eval > 0.85)
-        self.assertTrue(report.clean_train_adv_eval == 0.00)
+        self.assertGreater(report.clean_train_clean_eval, 0.85)
+        self.assertEqual(report.clean_train_adv_eval, 0.00)
 
         # There is no adversarial training in the CW tutorial
-        self.assertTrue(report.adv_train_clean_eval == 0.)
-        self.assertTrue(report.adv_train_adv_eval == 0.)
+        self.assertEqual(report.adv_train_clean_eval, 0.)
+        self.assertEqual(report.adv_train_adv_eval, 0.)
 
         g = tf.Graph()
         with g.as_default():


### PR DESCRIPTION
Using the mean value rather than a sum makes the loss invariant to batch size.
Invariance to batch size is nice if we want to search over hyperparameters or if we want to do synchronous multi-GPU training, since the size of the batch received by a single GPU is inverse proportional to the number of GPUs.