### PR TITLE
Unicode->Ascii Python2 fix for utils_mnist.

### DIFF
--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -10,6 +10,7 @@ import operator
 import os
 import struct
 import tempfile
+import sys
 
 import numpy as np
 

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -61,6 +61,9 @@ def download_and_parse_mnist_file(file_name, datadir=None, force=False):
             0x0e: 'd'}
         data_type = hex_to_data_type[data_type]
 
+        #data_type unicode to ascii conversion (Python2 fix)
+        data_type = data_type.encode('ascii','ignore')
+
         dim_sizes = struct.unpack(
             '>' + 'I' * n_dims,
             file_descriptor.read(4 * n_dims))

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -61,8 +61,8 @@ def download_and_parse_mnist_file(file_name, datadir=None, force=False):
             0x0e: 'd'}
         data_type = hex_to_data_type[data_type]
 
-        #data_type unicode to ascii conversion (Python2 fix)
-        data_type = data_type.encode('ascii','ignore')
+        # data_type unicode to ascii conversion (Python2 fix)
+        data_type = data_type.encode('ascii', 'ignore')
 
         dim_sizes = struct.unpack(
             '>' + 'I' * n_dims,

--- a/cleverhans/utils_mnist.py
+++ b/cleverhans/utils_mnist.py
@@ -62,7 +62,8 @@ def download_and_parse_mnist_file(file_name, datadir=None, force=False):
         data_type = hex_to_data_type[data_type]
 
         # data_type unicode to ascii conversion (Python2 fix)
-        data_type = data_type.encode('ascii', 'ignore')
+        if sys.version_info[0] < 3:
+            data_type = data_type.encode('ascii', 'ignore')
 
         dim_sizes = struct.unpack(
             '>' + 'I' * n_dims,


### PR DESCRIPTION
Mnist tutorial was broken with Python2, it invokes array.array method providing a unicode string param, where an ascii string is expected. This is a working fix.