### PR TITLE
Add missing value for NB_FILTERS in mnist_tutorial_tfe.py

### DIFF
--- a/cleverhans_tutorials/mnist_tutorial_tfe.py
+++ b/cleverhans_tutorials/mnist_tutorial_tfe.py
@@ -47,6 +47,7 @@ FLAGS = flags.FLAGS
 NB_EPOCHS = 6
 BATCH_SIZE = 128
 LEARNING_RATE = .001
+NB_FILTERS = 64
 
 # Keeps track of implemented attacks.
 # Maps attack string taken from bash to attack class


### PR DESCRIPTION
NB_FILTERS was missing from the mnist_tutorial_tfe.py file. 
I have added the same value as was present in mnist_tutorial_tf.py.