### PR TITLE
Update bundler to make it possible to control step sizes of both PGD attacks

### DIFF
--- a/cleverhans/attack_bundling.py
+++ b/cleverhans/attack_bundling.py
@@ -89,7 +89,7 @@ def single_run_max_confidence_recipe(sess, model, x, y, nb_classes, eps,
     cls_attack_config = AttackConfig(pgd_attack, cls_params, "pgd_" + str(cls))
     pgd_attack_configs.append(cls_attack_config)
     expensive_params = copy.copy(cls_params)
-    expensive_params["eps_iter"] /= eps_iter_small
+    expensive_params["eps_iter"] = eps_iter_small
     expensive_params["nb_iter"] *= 25.
     expensive_config = AttackConfig(pgd_attack, expensive_params, "expensive_pgd_" + str(cls))
     expensive_pgd.append(expensive_config)

--- a/cleverhans/attack_bundling.py
+++ b/cleverhans/attack_bundling.py
@@ -37,7 +37,8 @@ REPORT_TIME_INTERVAL = 60
 def single_run_max_confidence_recipe(sess, model, x, y, nb_classes, eps,
                                      clip_min, clip_max, eps_iter, nb_iter,
                                      report_path,
-                                     batch_size=BATCH_SIZE):
+                                     batch_size=BATCH_SIZE,
+                                     eps_iter_small=None):
   """A reasonable attack bundling recipe for a max norm threat model and
   a defender that uses confidence thresholding. This recipe uses both
   uniform noise and randomly-initialized PGD targeted attacks.
@@ -56,12 +57,16 @@ def single_run_max_confidence_recipe(sess, model, x, y, nb_classes, eps,
   :param y: numpy array containing true labels
   :param nb_classes: int, number of classes
   :param eps: float, maximum size of perturbation (measured by max norm)
-  :param eps_iter: float, step size for one version PGD attacks
-    (will also run another version with 25X smaller step size)
+  :param eps_iter: float, step size for one version of PGD attacks
+    (will also run another version with eps_iter_small step size)
   :param nb_iter: int, number of iterations for the cheaper PGD attacks
     (will also run another version with 25X more iterations)
   :param report_path: str, the path that the report will be saved to.
-  :batch_size: int, the total number of examples to run simultaneously
+  :param batch_size: int, the total number of examples to run simultaneously
+  :param eps_iter_small: optional, float.
+    The second version of the PGD attack is run with 25 * nb_iter iterations
+    and eps_iter_small step size. If eps_iter_small is not specified it is
+    set to eps_iter / 25.
   """
   noise_attack = Noise(model, sess)
   pgd_attack = ProjectedGradientDescent(model, sess)
@@ -76,13 +81,15 @@ def single_run_max_confidence_recipe(sess, model, x, y, nb_classes, eps,
   dev_batch_size = batch_size // num_devices
   ones = tf.ones(dev_batch_size, tf.int32)
   expensive_pgd = []
+  if eps_iter_small is None:
+    eps_iter_small = eps_iter / 25.
   for cls in range(nb_classes):
     cls_params = copy.copy(pgd_params)
     cls_params['y_target'] = tf.to_float(tf.one_hot(ones * cls, nb_classes))
     cls_attack_config = AttackConfig(pgd_attack, cls_params, "pgd_" + str(cls))
     pgd_attack_configs.append(cls_attack_config)
     expensive_params = copy.copy(cls_params)
-    expensive_params["eps_iter"] /= 25.
+    expensive_params["eps_iter"] /= eps_iter_small
     expensive_params["nb_iter"] *= 25.
     expensive_config = AttackConfig(pgd_attack, expensive_params, "expensive_pgd_" + str(cls))
     expensive_pgd.append(expensive_config)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -635,6 +635,11 @@ class ProjectedGradientDescent(Attack):
     self.clip_min = clip_min
     self.clip_max = clip_max
 
+    if isinstance(eps, float) and isinstance(eps_iter, float):
+      # If these are both known at compile time, we can check before anything
+      # is run. If they are tf, we can't check them yet.
+      assert eps_iter <= eps, (eps_iter, eps)
+
     if self.y is not None and self.y_target is not None:
       raise ValueError("Must not set both y and y_target")
     # Check if order of the norm is acceptable given current implementation

--- a/cleverhans/confidence_report.py
+++ b/cleverhans/confidence_report.py
@@ -108,6 +108,9 @@ def make_confidence_report_bundled(filepath, train_start=TRAIN_START,
   assert x_data.max() <= max_value
   assert x_data.min() >= min_value
 
+  assert eps_iter <= eps
+  assert eps_iter_small <= eps
+
   # Different recipes take different arguments.
   # For now I don't have an idea for a beautiful unifying framework, so
   # we get an if statement.

--- a/cleverhans/confidence_report.py
+++ b/cleverhans/confidence_report.py
@@ -86,14 +86,20 @@ def make_confidence_report_bundled(filepath, train_start=TRAIN_START,
   if 'CIFAR' in str(factory.cls):
     base_eps = 8. / 255.
     base_eps_iter = 2. / 255.
+    base_eps_iter_small = 1. / 255.
   elif 'MNIST' in str(factory.cls):
     base_eps = .3
     base_eps_iter = .1
+    base_eps_iter_small = None
   else:
     raise NotImplementedError(str(factory.cls))
 
   eps = base_eps * value_range
   eps_iter = base_eps_iter * value_range
+  if base_eps_iter_small is None:
+    eps_iter_small = None
+  else:
+    eps_iter_small = base_eps_iter_small * value_range
   nb_iter = 40
   clip_min = min_value
   clip_max = max_value
@@ -114,7 +120,7 @@ def make_confidence_report_bundled(filepath, train_start=TRAIN_START,
     run_recipe(sess=sess, model=model, x=x_data, y=y_data,
                nb_classes=dataset.NB_CLASSES, eps=eps, clip_min=clip_min,
                clip_max=clip_max, eps_iter=eps_iter, nb_iter=nb_iter,
-               report_path=report_path)
+               report_path=report_path, eps_iter_small=eps_iter_small)
 
 
 

--- a/scripts/make_confidence_report_bundled.py
+++ b/scripts/make_confidence_report_bundled.py
@@ -24,14 +24,14 @@ from __future__ import unicode_literals
 import tensorflow as tf
 from tensorflow.python.platform import flags
 
+from cleverhans.utils_tf import silence
+silence()
 from cleverhans.confidence_report import make_confidence_report_bundled
 from cleverhans.confidence_report import TRAIN_START, TRAIN_END
 from cleverhans.confidence_report import TEST_START, TEST_END
 from cleverhans.confidence_report import WHICH_SET
 from cleverhans.confidence_report import RECIPE
 from cleverhans.confidence_report import REPORT_PATH
-from cleverhans.utils_tf import silence
-silence()
 
 
 FLAGS = flags.FLAGS

--- a/scripts/make_confidence_report_bundled.py
+++ b/scripts/make_confidence_report_bundled.py
@@ -25,6 +25,9 @@ import tensorflow as tf
 from tensorflow.python.platform import flags
 
 from cleverhans.utils_tf import silence
+# The silence() call must precede other imports in order to silence them.
+# pylint does not like it but that's how it has to be.
+# pylint: disable=C0413
 silence()
 from cleverhans.confidence_report import make_confidence_report_bundled
 from cleverhans.confidence_report import TRAIN_START, TRAIN_END


### PR DESCRIPTION
Previously the second attack was hard-coded to have 25X smaller step size.
When eps is small to start with, this can result in the second eps_iter being absurdly small. I found that on CIFAR-10 the attack is stronger if I set the smaller eps_iter to 1./255 (the smallest variation present in the data) rather than to much smaller than that.