### PR TITLE
Fix most of the known problems with generate_np graph caching system

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -798,7 +798,7 @@ class MomentumIterativeMethod(Attack):
       ax = x + utils_tf.clip_eta(ax - x, self.ord, self.eps)
 
       if self.clip_min is not None and self.clip_max is not None:
-        ax = tf.clip_by_value(ax, self.clip_min, self.clip_max)
+        ax = utils_tf.clip_by_value(ax, self.clip_min, self.clip_max)
 
       ax = tf.stop_gradient(ax)
 

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -462,7 +462,7 @@ def fgm(x,
                               "currently implemented.")
 
   # Multiply by constant epsilon
-  scaled_grad = eps * normalized_grad
+  scaled_grad = utils_tf.mul(eps, normalized_grad)
 
   # Add perturbation to original example to obtain adversarial example
   adv_x = x + scaled_grad
@@ -533,8 +533,10 @@ class ProjectedGradientDescent(Attack):
 
     # Initialize loop variables
     if self.rand_init:
-      eta = tf.random_uniform(tf.shape(x), -self.rand_minmax,
-                              self.rand_minmax, dtype=self.tf_dtype)
+      eta = tf.random_uniform(tf.shape(x),
+                              tf.cast(-self.rand_minmax, x.dtype),
+                              tf.cast(self.rand_minmax, x.dtype),
+                              dtype=x.dtype)
     else:
       eta = tf.zeros(tf.shape(x))
     eta = clip_eta(eta, self.ord, self.eps)
@@ -576,7 +578,7 @@ class ProjectedGradientDescent(Attack):
 
       # Clipping perturbation according to clip_min and clip_max
       if self.clip_min is not None and self.clip_max is not None:
-        adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
+        adv_x = utils_tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
 
       # Clipping perturbation eta to self.ord norm ball
       eta = adv_x - x
@@ -589,7 +591,7 @@ class ProjectedGradientDescent(Attack):
     adv_x = x + eta
     if self.clip_min is not None or self.clip_max is not None:
       assert self.clip_min is not None and self.clip_max is not None
-      adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
+      adv_x = utils_tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
 
     asserts = []
 

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -165,7 +165,7 @@ class Attack(object):
                        " provided")
 
     packed = self.construct_variables(kwargs)
-    fixed, feedable, feedable_types, hash_key = packed
+    fixed, feedable, _feedable_types, hash_key = packed
 
     if hash_key not in self.graphs:
       self.construct_graph(fixed, feedable, x_val, hash_key)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -123,9 +123,9 @@ class Attack(object):
       given_type = value.dtype
       if isinstance(value, np.ndarray):
         new_shape = [None] + list(value.shape[1:])
-        new_kwargs[name] = tf.placeholder(given_type, new_shape)
+        new_kwargs[name] = tf.placeholder(given_type, new_shape, name=name)
       elif isinstance(value, utils.known_number_types):
-        new_kwargs[name] = tf.placeholder(given_type, shape=[])
+        new_kwargs[name] = tf.placeholder(given_type, shape=[], name=name)
       else:
         raise ValueError("Could not identify type of argument " +
                          name + ": " + str(value))
@@ -2313,7 +2313,7 @@ def arg_type(arg_names, kwargs):
     if value is None:
       dtypes.append(None)
       continue
-    assert hasattr(value, 'dtype')
+    assert hasattr(value, 'dtype'), type(value)
     dtype = value.dtype
     if not isinstance(dtype, np.dtype):
       dtype = dtype.as_np_dtype

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -210,6 +210,9 @@ class Attack(object):
     # the set of arguments that are passed as placeholders to the graph
     # on each call, and can change without constructing a new graph
     feedable = {k: v for k, v in kwargs.items() if k in feedable_names}
+    for k in feedable:
+      if isinstance(feedable[k], (float, int)):
+        feedable[k] = np.array(feedable[k])
 
     for key in kwargs:
       if key not in fixed and key not in feedable:

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -763,10 +763,10 @@ class MomentumIterativeMethod(Attack):
 
     # If a data range was specified, check that the input was in that range
     if self.clip_min is not None:
-      asserts.append(utils_tf.assert_greater_equal(x, self.clip_min))
+      asserts.append(utils_tf.assert_greater_equal(x, tf.cast(self.clip_min, x.dtype)))
 
     if self.clip_max is not None:
-      asserts.append(utils_tf.assert_less_equal(x, self.clip_max))
+      asserts.append(utils_tf.assert_less_equal(x, tf.cast(self.clip_max, x.dtype)))
 
     # Initialize loop variables
     momentum = tf.zeros_like(x)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -791,7 +791,7 @@ class MomentumIterativeMethod(Attack):
                                   "currently implemented.")
 
       # Update and clip adversarial example in current iteration
-      scaled_grad = self.eps_iter * normalized_grad
+      scaled_grad = utils_tf.mul(self.eps_iter, normalized_grad)
       ax = ax + scaled_grad
       ax = x + utils_tf.clip_eta(ax - x, self.ord, self.eps)
 

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -120,7 +120,7 @@ class Attack(object):
     # process all of the rest and create placeholders for them
     new_kwargs = dict(x for x in fixed.items())
     for name, value in feedable.items():
-      given_type = self.feedable_kwargs[name]
+      given_type = value.dtype
       if isinstance(value, np.ndarray):
         new_shape = [None] + list(value.shape[1:])
         new_kwargs[name] = tf.placeholder(given_type, new_shape)
@@ -158,7 +158,8 @@ class Attack(object):
       raise ValueError("Cannot use `generate_np` when no `sess` was"
                        " provided")
 
-    fixed, feedable, hash_key = self.construct_variables(kwargs)
+    packed = self.construct_variables(kwargs)
+    fixed, feedable, feedable_types, hash_key = packed
 
     if hash_key not in self.graphs:
       self.construct_graph(fixed, feedable, x_val, hash_key)
@@ -182,9 +183,25 @@ class Attack(object):
     Construct the inputs to the attack graph to be used by generate_np.
 
     :param kwargs: Keyword arguments to generate_np.
-    :return: Structural and feedable arguments as well as a unique key
-             for the graph given these inputs.
+    :return:
+      Structural arguments
+      Feedable arguments
+      Output of `arg_type` describing feedable arguments
+      A unique key
     """
+    if isinstance(self.feedable_kwargs, dict):
+      warnings.warn("Using a dict for `feedable_kwargs is deprecated."
+                    "Switch to using a tuple."
+                    "It is not longer necessary to specify the types "
+                    "of the arguments---we build a different graph "
+                    "for each received type."
+                    "Using a dict may become an error on or after "
+                    "2019-04-18.")
+      feedable_names = tuple(sorted(self.feedable_kwargs.keys()))
+    else:
+      feedable_names = self.feedable_kwargs
+      assert isinstance(feedable_names, tuple)
+
     # the set of arguments that are structural properties of the attack
     # if these arguments are different, we must construct a new graph
     fixed = dict(
@@ -192,12 +209,13 @@ class Attack(object):
 
     # the set of arguments that are passed as placeholders to the graph
     # on each call, and can change without constructing a new graph
-    feedable = dict(
-        (k, v) for k, v in kwargs.items() if k in self.feedable_kwargs)
+    feedable = {k: v for k, v in kwargs.items() if k in feedable_names}
 
     for key in kwargs:
       if key not in fixed and key not in feedable:
         raise ValueError("Undeclared argument: " + key)
+
+    feed_arg_type = arg_type(feedable_names, feedable)
 
     if not all(isinstance(value, collections.Hashable)
                for value in fixed.values()):
@@ -207,9 +225,9 @@ class Attack(object):
       hash_key = None
     else:
       # create a unique key for this set of fixed paramaters
-      hash_key = tuple(sorted(fixed.items()))
+      hash_key = tuple(sorted(fixed.items())) + tuple([feed_arg_type])
 
-    return fixed, feedable, hash_key
+    return fixed, feedable, feed_arg_type, hash_key
 
   def get_or_guess_labels(self, x, kwargs):
     """
@@ -843,7 +861,7 @@ class SaliencyMapMethod(Attack):
 
     super(SaliencyMapMethod, self).__init__(model, sess, dtypestr, **kwargs)
 
-    self.feedable_kwargs = {'y_target': self.tf_dtype}
+    self.feedable_kwargs = tuple(['y_target'])
     self.structural_kwargs = [
         'theta', 'gamma', 'clip_max', 'clip_min', 'symbolic_impl'
     ]
@@ -2269,3 +2287,34 @@ class MaxConfidence(Attack):
   def attack_class(self, x, target_y):
     adv = self.base_attacker.generate(x, y_target=target_y, **self.params)
     return adv
+
+def arg_type(arg_names, kwargs):
+  """
+  Returns a hashable summary of the types of arg_names within kwargs.
+  """
+  assert isinstance(arg_names, tuple)
+  passed = (name in kwargs for name in arg_names)
+  passed_and_not_none = []
+  for name in arg_names:
+    if name in kwargs:
+      passed_and_not_none.append(kwargs[name] is not None)
+    else:
+      passed_and_not_none.append(False)
+  passed_and_not_none = tuple(passed_and_not_none)
+  dtypes = []
+  for name in arg_names:
+    if name not in kwargs:
+      dtypes.append(None)
+      continue
+    value = kwargs[name]
+    if value is None:
+      dtypes.append(None)
+      continue
+    assert hasattr(value, 'dtype')
+    dtype = value.dtype
+    if not isinstance(dtype, np.dtype):
+      dtype = dtype.as_np_dtype
+    assert isinstance(dtype, np.dtype)
+    dtypes.append(dtype)
+  dtypes = tuple(dtypes)
+  return (passed, passed_and_not_none, dtypes)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -471,11 +471,7 @@ def fgm(x,
   if (clip_min is not None) or (clip_max is not None):
     # We don't currently support one-sided clipping
     assert clip_min is not None and clip_max is not None
-    if adv_x.dtype == tf.float32 and clip_min.dtype != tf.float32:
-      clip_min = tf.cast(clip_min, tf.float32)
-    if adv_x.dtype == tf.float32 and clip_max.dtype != tf.float32:
-      clip_max = tf.cast(clip_max, tf.float32)
-    adv_x = tf.clip_by_value(adv_x, clip_min, clip_max)
+    adv_x = utils_tf.clip_by_value(adv_x, clip_min, clip_max)
 
   return adv_x
 

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -468,7 +468,13 @@ def fgm(x,
   adv_x = x + scaled_grad
 
   # If clipping is needed, reset all values outside of [clip_min, clip_max]
-  if (clip_min is not None) and (clip_max is not None):
+  if (clip_min is not None) or (clip_max is not None):
+    # We don't currently support one-sided clipping
+    assert clip_min is not None and clip_max is not None
+    if adv_x.dtype == tf.float32 and clip_min.dtype != tf.float32:
+      clip_min = tf.cast(clip_min, tf.float32)
+    if adv_x.dtype == tf.float32 and clip_max.dtype != tf.float32:
+      clip_max = tf.cast(clip_max, tf.float32)
     adv_x = tf.clip_by_value(adv_x, clip_min, clip_max)
 
   return adv_x

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -565,7 +565,7 @@ class ProjectedGradientDescent(Attack):
     eta = clip_eta(eta, self.ord, self.eps)
     adv_x = x + eta
     if self.clip_min is not None or self.clip_max is not None:
-      adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
+      adv_x = utils_tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
 
     # Fix labels to the first model predictions for loss computation
     model_preds = self.model.get_probs(x)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -122,8 +122,14 @@ class Attack(object):
     for name, value in feedable.items():
       given_type = value.dtype
       if isinstance(value, np.ndarray):
-        new_shape = [None] + list(value.shape[1:])
-        new_kwargs[name] = tf.placeholder(given_type, new_shape, name=name)
+        if value.ndim == 0:
+          # This is pretty clearly not a batch of data
+          new_kwargs[name] = tf.placeholder(given_type, shape=[], name=name)
+        else:
+          # Assume that this is a batch of data, make the first axis variable
+          # in size
+          new_shape = [None] + list(value.shape[1:])
+          new_kwargs[name] = tf.placeholder(given_type, new_shape, name=name)
       elif isinstance(value, utils.known_number_types):
         new_kwargs[name] = tf.placeholder(given_type, shape=[], name=name)
       else:

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -165,7 +165,7 @@ class Attack(object):
                        " provided")
 
     packed = self.construct_variables(kwargs)
-    fixed, feedable, _feedable_types, hash_key = packed
+    fixed, feedable, _, hash_key = packed
 
     if hash_key not in self.graphs:
       self.construct_graph(fixed, feedable, x_val, hash_key)
@@ -870,7 +870,7 @@ class SaliencyMapMethod(Attack):
 
     super(SaliencyMapMethod, self).__init__(model, sess, dtypestr, **kwargs)
 
-    self.feedable_kwargs = tuple(['y_target'])
+    self.feedable_kwargs = ('y_target',)
     self.structural_kwargs = [
         'theta', 'gamma', 'clip_max', 'clip_min', 'symbolic_impl'
     ]
@@ -2300,6 +2300,20 @@ class MaxConfidence(Attack):
 def arg_type(arg_names, kwargs):
   """
   Returns a hashable summary of the types of arg_names within kwargs.
+  :param arg_names: tuple containing names of relevant arguments
+  :param kwargs: dict mapping string argument names to values.
+    These must be values for which we can create a tf placeholder.
+    Currently supported: numpy darray or something that can ducktype it
+  returns:
+    API contract is to return a hashable object describing all
+    structural consequences of argument values that can otherwise
+    be fed into a graph of fixed structure.
+    Currently this is implemented as a tuple of tuples that track:
+      - whether each argument was passed
+      - whether each argument was passed and not None
+      - the dtype of each argument
+    Callers shouldn't rely on the exact structure of this object,
+    just its hashability and one-to-one mapping between graph structures.
   """
   assert isinstance(arg_names, tuple)
   passed = (name in kwargs for name in arg_names)

--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -425,10 +425,10 @@ def fgm(x,
 
   # If a data range was specified, check that the input was in that range
   if clip_min is not None:
-    asserts.append(utils_tf.assert_greater_equal(x, clip_min))
+    asserts.append(utils_tf.assert_greater_equal(x, tf.cast(clip_min, x.dtype)))
 
   if clip_max is not None:
-    asserts.append(utils_tf.assert_less_equal(x, clip_max))
+    asserts.append(utils_tf.assert_less_equal(x, tf.cast(clip_max, x.dtype)))
 
   # Make sure the caller has not passed probs by accident
   assert logits.op.type != 'Softmax'

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -1727,7 +1727,7 @@ def _project_perturbation(perturbation, epsilon, input_image):
       tf.assert_less_equal(input_image, 1.0),
       tf.assert_greater_equal(input_image, 0.0)
   ]):
-    clipped_perturbation = tf.clip_by_value(
+    clipped_perturbation = utils_tf.clip_by_value(
         perturbation, -epsilon, epsilon)
     new_image = tf.clip_by_value(
         input_image + clipped_perturbation, 0., 1.)
@@ -1779,7 +1779,10 @@ def pgd_attack(loss_fn,
           "Starting PGD attack with epsilon: %s" % epsilon)
 
   init_perturbation = tf.random_uniform(
-      tf.shape(input_image), minval=-epsilon, maxval=epsilon, dtype=tf_dtype)
+      tf.shape(input_image),
+      minval=tf.cast(-epsilon, input_image.dtype),
+      maxval=tf.cast(epsilon, input_image.dtype),
+      dtype=input_image.dtype)
   init_perturbation = project_perturbation(init_perturbation, epsilon,
                                            input_image)
   init_optim_state = optimizer.init_state([init_perturbation])
@@ -1822,7 +1825,8 @@ def pgd_attack(loss_fn,
   if project_perturbation is _project_perturbation:
     perturbation_max = epsilon * 1.1
     check_diff = tf.assert_less_equal(
-        final_perturbation, perturbation_max,
+        final_perturbation,
+        tf.cast(perturbation_max, final_perturbation.dtype),
         message="final_perturbation must change no pixel by more than "
                 "%s" % perturbation_max)
   else:

--- a/cleverhans/attacks_tf.py
+++ b/cleverhans/attacks_tf.py
@@ -414,6 +414,14 @@ def jsma_symbolic(x, y_target, model, theta, gamma, clip_min, clip_max):
   nb_classes = int(y_target.shape[-1].value)
   nb_features = int(np.product(x.shape[1:]).value)
 
+  if x.dtype == tf.float32 and y_target.dtype == tf.int64:
+    y_target = tf.cast(y_target, tf.int32)
+
+  if x.dtype == tf.float32 and y_target.dtype == tf.float64:
+    warnings.warn("Downcasting labels---this should be harmless unless"
+                  " they are smoothed")
+    y_target = tf.cast(y_target, tf.float32)
+
   max_iters = np.floor(nb_features * gamma / 2)
   increase = bool(theta > 0)
 

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -527,3 +527,13 @@ def silence():
   Silences tensorflaw's default printed messages
   """
   os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+
+def clip_by_value(t, clip_value_min, clip_value_max, name=None):
+  """
+  A wrapper for clip_by_value that downcasts the clipping range if needed.
+  """
+  if t.dtype == tf.float32 and clip_value_min.dtype != tf.float32:
+    clip_value_min = tf.cast(clip_value_min, tf.float32)
+  if t.dtype == tf.float32 and clip_value_max.dtype != tf.float32:
+    clip_value_max = tf.cast(clip_value_max, tf.float32)
+  return tf.clip_by_value(t, clip_value_min, clip_value_max, name)

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -626,4 +626,3 @@ def assert_equal(*args, **kwargs):
   """
   with tf.device("/CPU:0"):
     return tf.assert_equal(*args, **kwargs)
-

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -574,7 +574,7 @@ def op_with_scalar_cast(a, b, f):
 
   try:
     return f(a, b)
-  except TypeError:
+  except (TypeError, ValueError):
     pass
 
   def is_scalar(x):

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -532,8 +532,14 @@ def clip_by_value(t, clip_value_min, clip_value_max, name=None):
   """
   A wrapper for clip_by_value that downcasts the clipping range if needed.
   """
-  if t.dtype == tf.float32 and clip_value_min.dtype != tf.float32:
-    clip_value_min = tf.cast(clip_value_min, tf.float32)
-  if t.dtype == tf.float32 and clip_value_max.dtype != tf.float32:
-    clip_value_max = tf.cast(clip_value_max, tf.float32)
+  def cast_clip(clip):
+    if t.dtype == tf.float32:
+      if hasattr(clip, 'dtype'):
+        if clip.dtype != tf.float32:
+          return tf.cast(clip, tf.float32)
+    return clip
+
+  clip_value_min = cast_clip(clip_value_min)
+  clip_value_max = cast_clip(clip_value_max)
+
   return tf.clip_by_value(t, clip_value_min, clip_value_max, name)

--- a/examples/multigpu_advtrain/attacks_multigpu.py
+++ b/examples/multigpu_advtrain/attacks_multigpu.py
@@ -108,7 +108,7 @@ class MadryEtAlMultiGPU(MadryEtAl):
     """
     Facilitates testing this attack.
     """
-    _, feedable, hash_key = self.construct_variables(kwargs)
+    _, feedable, _feedable_types, hash_key = self.construct_variables(kwargs)
 
     if hash_key not in self.graphs:
       with tf.variable_scope(None, 'attack_%d' % len(self.graphs)):

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -718,7 +718,7 @@ class TestSaliencyMapMethod(CleverHansTest):
     x_val = np.random.rand(10, 1000)
     x_val = np.array(x_val, dtype=np.float32)
 
-    feed_labs = np.zeros((10, 10))
+    feed_labs = np.zeros((10, 10), dtype=np.float32)
     feed_labs[np.arange(10), np.random.randint(0, 9, 10)] = 1
     x_adv = self.attack.generate_np(x_val,
                                     clip_min=-5., clip_max=5.,

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -432,8 +432,7 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=-5,
-                                    clip_max=3,
+                                    clip_min=-5, clip_max=5,
                                     batch_size=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -629,8 +628,7 @@ class TestElasticNetMethod(CleverHansTest):
                                     binary_search_steps=1,
                                     learning_rate=1e-3,
                                     initial_const=1,
-                                    clip_min=-0.2,
-                                    clip_max=0.3,
+                                    clip_min=-0.2, clip_max=0.3,
                                     batch_size=100)
 
     self.assertTrue(-0.201 < np.min(x_adv))
@@ -717,9 +715,9 @@ class TestSaliencyMapMethod(CleverHansTest):
 
   def test_generate_np_targeted_gives_adversarial_example(self):
     x_val = np.random.rand(10, 1000)
-    x_val = np.array(x_val)
+    x_val = np.array(x_val, dtype=np.float32)
 
-    feed_labs = np.zeros((10, 10), dtype=np.float32)
+    feed_labs = np.zeros((10, 10))
     feed_labs[np.arange(10), np.random.randint(0, 9, 10)] = 1
     x_adv = self.attack.generate_np(x_val,
                                     clip_min=-5., clip_max=5.,
@@ -744,7 +742,7 @@ class TestDeepFool(CleverHansTest):
 
     x_adv = self.attack.generate_np(x_val, over_shoot=0.02, max_iter=50,
                                     nb_candidate=2, clip_min=-5,
-                                    clip_max=3)
+                                    clip_max=5)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 import tensorflow.contrib.slim as slim
 import unittest
 import numpy as np
+from numpy import float32
 
 from cleverhans.devtools.checks import CleverHansTest
 
@@ -173,7 +174,8 @@ class TestFastGradientMethod(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     x_adv = self.attack.generate_np(x_val, eps=eps, ord=ord,
-                                    clip_min=-5, clip_max=5, **kwargs)
+                                    clip_min=float32(-5), clip_max=float32(5),
+                                    **kwargs)
     if ord == np.inf:
       delta = np.max(np.abs(x_adv - x_val), axis=1)
     elif ord == 1:
@@ -228,7 +230,8 @@ class TestFastGradientMethod(CleverHansTest):
     for eps in [0.1, 0.2, 0.3, 0.4]:
       eps = np.array(eps, dtype='float32')
       x_adv = self.attack.generate_np(x_val, eps=eps, ord=np.inf,
-                                      clip_min=-5.0, clip_max=5.0)
+                                      clip_min=float32(-5.0),
+                                      clip_max=float32(5.0))
 
       delta = np.max(np.abs(x_adv - x_val), axis=1)
       self.assertClose(delta, eps)
@@ -239,7 +242,8 @@ class TestFastGradientMethod(CleverHansTest):
 
     x_adv = self.attack.generate_np(x_val, eps=np.array(0.5, 'float32'),
                                     ord=np.inf,
-                                    clip_min=-0.2, clip_max=0.1)
+                                    clip_min=float32(-0.2),
+                                    clip_max=float32(0.1))
 
     self.assertClose(np.min(x_adv), -0.2)
     self.assertClose(np.max(x_adv), 0.1)
@@ -364,8 +368,9 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=1.0, ord=np.inf,
-                                    clip_min=0.5, clip_max=0.7,
+    x_adv = self.attack.generate_np(x_val, eps=float32(1.0), ord=np.inf,
+                                    clip_min=float32(0.5),
+                                    clip_max=float32(0.7),
                                     nb_iter=5)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -376,8 +381,9 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=1.0, ord=np.inf,
-                                    clip_min=-5.0, clip_max=5.0,
+    x_adv = self.attack.generate_np(x_val, eps=float32(1.0), ord=np.inf,
+                                    clip_min=float32(-5.0),
+                                    clip_max=float32(5.0),
                                     nb_iter=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -393,8 +399,9 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
 
     tf.gradients = fn
 
-    x_adv = self.attack.generate_np(x_val, eps=1.0, ord=np.inf,
-                                    clip_min=-5.0, clip_max=5.0,
+    x_adv = self.attack.generate_np(x_val, eps=float32(1.0), ord=np.inf,
+                                    clip_min=float32(-5.0),
+                                    clip_max=float32(5.0),
                                     nb_iter=11)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -419,9 +426,10 @@ class TestMomentumIterativeMethod(TestBasicIterativeMethod):
     x_val = np.array(x_val, dtype=np.float32)
 
     for decay_factor in [0.0, 0.5, 1.0]:
-      x_adv = self.attack.generate_np(x_val, eps=0.5, ord=np.inf,
+      x_adv = self.attack.generate_np(x_val, eps=float32(0.5), ord=np.inf,
                                       decay_factor=decay_factor,
-                                      clip_min=-5.0, clip_max=5.0)
+                                      clip_min=float32(-5.0),
+                                      clip_max=float32(5.0))
 
       delta = np.max(np.abs(x_adv - x_val), axis=1)
       self.assertClose(delta, 0.5)
@@ -442,7 +450,8 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=-5, clip_max=5,
+                                    clip_min=float32(-5),
+                                    clip_max=float32(5),
                                     batch_size=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -459,7 +468,7 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=-5, clip_max=5,
+                                    clip_min=float32(-5), clip_max=float32(5),
                                     batch_size=100, y_target=feed_labs)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -481,7 +490,8 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv_p = self.attack.generate(x, max_iterations=100,
                                    binary_search_steps=3,
                                    initial_const=1,
-                                   clip_min=-5, clip_max=5,
+                                   clip_min=float32(-5),
+                                   clip_max=float32(5),
                                    batch_size=100, y=y)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val, y: feed_labs})
@@ -498,7 +508,8 @@ class TestCarliniWagnerL2(CleverHansTest):
                                     binary_search_steps=1,
                                     learning_rate=1e-3,
                                     initial_const=1,
-                                    clip_min=-0.2, clip_max=0.3,
+                                    clip_min=float32(-0.2),
+                                    clip_max=float32(0.3),
                                     batch_size=100)
 
     self.assertTrue(-0.201 < np.min(x_adv))
@@ -520,7 +531,8 @@ class TestCarliniWagnerL2(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=-10, clip_max=10,
+                                 clip_min=float32(-10),
+                                 clip_max=float32(10),
                                  confidence=CONFIDENCE,
                                  y_target=feed_labs,
                                  batch_size=10)
@@ -552,7 +564,7 @@ class TestCarliniWagnerL2(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=-10, clip_max=10,
+                                 clip_min=float32(-10), clip_max=float32(10),
                                  confidence=CONFIDENCE,
                                  batch_size=10)
 
@@ -582,7 +594,8 @@ class TestElasticNetMethod(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=-5, clip_max=5,
+                                    clip_min=float32(-5),
+                                    clip_max=float32(5),
                                     batch_size=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -599,7 +612,7 @@ class TestElasticNetMethod(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=-5, clip_max=5,
+                                    clip_min=float32(-5), clip_max=float32(5),
                                     batch_size=100, y_target=feed_labs)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -621,7 +634,7 @@ class TestElasticNetMethod(CleverHansTest):
     x_adv_p = self.attack.generate(x, max_iterations=100,
                                    binary_search_steps=3,
                                    initial_const=1,
-                                   clip_min=-5, clip_max=5,
+                                   clip_min=float32(-5), clip_max=float32(5),
                                    batch_size=100, y=y)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val, y: feed_labs})
@@ -638,7 +651,8 @@ class TestElasticNetMethod(CleverHansTest):
                                     binary_search_steps=1,
                                     learning_rate=1e-3,
                                     initial_const=1,
-                                    clip_min=-0.2, clip_max=0.3,
+                                    clip_min=float32(-0.2),
+                                    clip_max=float32(0.3),
                                     batch_size=100)
 
     self.assertTrue(-0.201 < np.min(x_adv))
@@ -660,7 +674,7 @@ class TestElasticNetMethod(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=-10, clip_max=10,
+                                 clip_min=float32(-10), clip_max=float32(10),
                                  confidence=CONFIDENCE,
                                  y_target=feed_labs,
                                  batch_size=10)
@@ -692,7 +706,7 @@ class TestElasticNetMethod(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=-10, clip_max=10,
+                                 clip_min=float32(-10), clip_max=float32(10),
                                  confidence=CONFIDENCE,
                                  batch_size=10)
 
@@ -730,7 +744,8 @@ class TestSaliencyMapMethod(CleverHansTest):
     feed_labs = np.zeros((10, 10), dtype=np.float32)
     feed_labs[np.arange(10), np.random.randint(0, 9, 10)] = 1
     x_adv = self.attack.generate_np(x_val,
-                                    clip_min=-5., clip_max=5.,
+                                    clip_min=float32(-5.),
+                                    clip_max=float32(5.),
                                     y_target=feed_labs)
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
 
@@ -751,8 +766,8 @@ class TestDeepFool(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     x_adv = self.attack.generate_np(x_val, over_shoot=0.02, max_iter=50,
-                                    nb_candidate=2, clip_min=-5,
-                                    clip_max=5)
+                                    nb_candidate=2, clip_min=float32(-5),
+                                    clip_max=float32(5))
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -767,7 +782,7 @@ class TestDeepFool(CleverHansTest):
     x = tf.placeholder(tf.float32, x_val.shape)
 
     x_adv_p = self.attack.generate(x, over_shoot=0.02, max_iter=50,
-                                   nb_candidate=2, clip_min=-5, clip_max=5)
+                                   nb_candidate=2, clip_min=float32(-5), clip_max=float32(5))
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val})
 
@@ -780,8 +795,8 @@ class TestDeepFool(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     x_adv = self.attack.generate_np(x_val, over_shoot=0.02, max_iter=50,
-                                    nb_candidate=2, clip_min=-0.2,
-                                    clip_max=0.3)
+                                    nb_candidate=2, clip_min=float32(-0.2),
+                                    clip_max=float32(0.3))
 
     self.assertTrue(-0.201 < np.min(x_adv))
     self.assertTrue(np.max(x_adv) < .301)
@@ -804,8 +819,10 @@ class TestMadryEtAl(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=1.0, eps_iter=0.05,
-                                    clip_min=0.5, clip_max=0.7,
+    x_adv = self.attack.generate_np(x_val, eps=float32(1.0),
+                                    eps_iter=float32(0.05),
+                                    clip_min=float32(0.5),
+                                    clip_max=float32(0.7),
                                     nb_iter=5, sanity_checks=False)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -816,7 +833,8 @@ class TestMadryEtAl(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=1.0, eps_iter=0.1,
+    x_adv = self.attack.generate_np(x_val, eps=float32(1.0),
+                                    eps_iter=float32(0.1),
                                     nb_iter=5)
 
     delta = np.max(np.abs(x_adv - x_val), axis=1)
@@ -826,9 +844,11 @@ class TestMadryEtAl(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=1.0, eps_iter=0.1,
+    x_adv = self.attack.generate_np(x_val, eps=float32(1.0),
+                                    eps_iter=float32(0.1),
                                     nb_iter=5,
-                                    clip_min=-0.2, clip_max=0.3,
+                                    clip_min=float32(-0.2),
+                                    clip_max=float32(0.3),
                                     sanity_checks=False)
 
     self.assertLess(-0.201, np.min(x_adv))
@@ -935,8 +955,8 @@ class TestFastFeatureAdversaries(CleverHansTest):
     x_guide = tf.abs(tf.random_uniform(input_shape, 0., 1.))
 
     layer = 'fc7'
-    attack_params = {'eps': 5. / 256, 'clip_min': 0., 'clip_max': 1.,
-                     'nb_iter': 10, 'eps_iter': 0.005,
+    attack_params = {'eps': float32(5. / 256), 'clip_min': float32(0.), 'clip_max': 1.,
+                     'nb_iter': 10, 'eps_iter': float32(0.005),
                      'layer': layer}
     x_adv = self.attack.generate(x_src, x_guide, **attack_params)
     h_adv = self.model.fprop(x_adv)[layer]
@@ -978,7 +998,7 @@ class TestLBFGS(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=-5, clip_max=5,
+                                    clip_min=float32(-5), clip_max=float32(5),
                                     batch_size=100, y_target=feed_labs)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -998,7 +1018,7 @@ class TestLBFGS(CleverHansTest):
     x_adv_p = self.attack.generate(x, max_iterations=100,
                                    binary_search_steps=3,
                                    initial_const=1,
-                                   clip_min=-5, clip_max=5,
+                                   clip_min=float32(-5), clip_max=float32(5),
                                    batch_size=100, y_target=y)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val, y: feed_labs})
@@ -1017,7 +1037,7 @@ class TestLBFGS(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=10,
                                     binary_search_steps=1,
                                     initial_const=1,
-                                    clip_min=-0.2, clip_max=0.3,
+                                    clip_min=float32(-0.2), clip_max=float32(0.3),
                                     batch_size=100, y_target=feed_labs)
 
     self.assertTrue(-0.201 < np.min(x_adv))

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -291,9 +291,9 @@ class TestSPSA(CleverHansTest):
     for i in range(n_samples):
       x_adv_np = self.attack.generate_np(
           np.expand_dims(x_val[i], axis=0),
-          y=np.expand_dims(feed_labs[i], axis=0),
-          epsilon=.5, num_steps=100, batch_size=64, spsa_iters=1,
-      )
+          y=np.expand_dims(feed_labs[i], axis=0).astype('int32'),
+          epsilon=np.array(.5, dtype='float32'), num_steps=100, batch_size=64,
+          spsa_iters=1)
       all_x_adv.append(x_adv_np[0])
 
     x_adv = np.vstack(all_x_adv)

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -174,7 +174,7 @@ class TestFastGradientMethod(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     x_adv = self.attack.generate_np(x_val, eps=eps, ord=ord,
-                                    clip_min=float32(-5), clip_max=float32(5),
+                                    clip_min=-5, clip_max=5,
                                     **kwargs)
     if ord == np.inf:
       delta = np.max(np.abs(x_adv - x_val), axis=1)

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -226,6 +226,7 @@ class TestFastGradientMethod(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     for eps in [0.1, 0.2, 0.3, 0.4]:
+      eps = np.array(eps, dtype='float32')
       x_adv = self.attack.generate_np(x_val, eps=eps, ord=np.inf,
                                       clip_min=-5.0, clip_max=5.0)
 
@@ -236,7 +237,8 @@ class TestFastGradientMethod(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=0.5, ord=np.inf,
+    x_adv = self.attack.generate_np(x_val, eps=np.array(0.5, 'float32'),
+                                    ord=np.inf,
                                     clip_min=-0.2, clip_max=0.1)
 
     self.assertClose(np.min(x_adv), -0.2)
@@ -324,15 +326,21 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
     self.attack = BasicIterativeMethod(self.model, sess=self.sess)
 
   def test_generate_np_gives_adversarial_example_linfinity(self):
-    self.help_generate_np_gives_adversarial_example(ord=np.infty, eps=.5,
+    self.help_generate_np_gives_adversarial_example(ord=np.infty,
+                                                    eps=np.array(.5,
+                                                                 'float32'),
                                                     nb_iter=20)
 
   def test_generate_np_gives_adversarial_example_l1(self):
-    self.help_generate_np_gives_adversarial_example(ord=1, eps=.5,
+    self.help_generate_np_gives_adversarial_example(ord=1,
+                                                    eps=np.array(.5,
+                                                                 'float32'),
                                                     nb_iter=20)
 
   def test_generate_np_gives_adversarial_example_l2(self):
-    self.help_generate_np_gives_adversarial_example(ord=2, eps=.5,
+    self.help_generate_np_gives_adversarial_example(ord=2,
+                                                    eps=np.array(.5,
+                                                                 'float32'),
                                                     nb_iter=20)
 
   def test_do_not_reach_lp_boundary(self):
@@ -343,7 +351,8 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
     """
     for ord in [1, 2, np.infty]:
       _, _, delta = self.generate_adversarial_examples_np(
-          ord=ord, eps=.5, nb_iter=10, eps_iter=.01)
+          ord=ord, eps=np.array(.5, 'float32'), nb_iter=10,
+          eps_iter=np.array(.01, 'float32'))
       self.assertTrue(np.max(0.5 - delta) > 0.25)
 
   def test_attack_strength(self):
@@ -841,8 +850,10 @@ class TestMadryEtAl(CleverHansTest):
 
     # Generate multiple adversarial examples
     for i in range(10):
-      x_adv = self.attack.generate_np(x_val, eps=.5, eps_iter=0.05,
-                                      clip_min=0.5, clip_max=0.7,
+      x_adv = self.attack.generate_np(x_val, eps=np.array(.5, 'float32'),
+                                      eps_iter=np.array(0.05, 'float32'),
+                                      clip_min=np.array(0.5, 'float32'),
+                                      clip_max=np.array(0.7, 'float32'),
                                       nb_iter=2, sanity_checks=False)
       new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
 

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -308,8 +308,8 @@ class TestSPSA(CleverHansTest):
 
     feed_labs = np.random.randint(0, 2, n_samples)
     x_adv = self.attack.generate_np(
-        x_val, y=feed_labs, epsilon=.5, num_steps=100, batch_size=64,
-        spsa_iters=1)
+        x_val, y=feed_labs.astype('int32'), epsilon=np.array(.5, dtype='float32'), num_steps=100,
+        batch_size=64, spsa_iters=1)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
     self.assertTrue(np.mean(feed_labs == new_labs) < 0.1)

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -187,6 +187,7 @@ class TestFastGradientMethod(CleverHansTest):
 
   def help_generate_np_gives_adversarial_example(self, ord, eps=.5,
                                                  **kwargs):
+    eps = float32(eps)
     x_val, x_adv, delta = self.generate_adversarial_examples_np(ord, eps,
                                                                 **kwargs)
     self.assertClose(delta, eps)
@@ -212,11 +213,11 @@ class TestFastGradientMethod(CleverHansTest):
 
   def test_targeted_generate_np_gives_adversarial_example(self):
     random_labs = np.random.random_integers(0, 1, 100)
-    random_labs_one_hot = np.zeros((100, 2))
+    random_labs_one_hot = np.zeros((100, 2), dtype='int32')
     random_labs_one_hot[np.arange(100), random_labs] = 1
 
     _, x_adv, delta = self.generate_adversarial_examples_np(
-        eps=.5, ord=np.inf, y_target=random_labs_one_hot)
+        eps=float32(.5), ord=np.inf, y_target=random_labs_one_hot)
 
     self.assertClose(delta, 0.5)
 

--- a/tests_tf/test_attacks.py
+++ b/tests_tf/test_attacks.py
@@ -8,7 +8,6 @@ import tensorflow as tf
 import tensorflow.contrib.slim as slim
 import unittest
 import numpy as np
-from numpy import float32
 
 from cleverhans.devtools.checks import CleverHansTest
 
@@ -187,7 +186,7 @@ class TestFastGradientMethod(CleverHansTest):
 
   def help_generate_np_gives_adversarial_example(self, ord, eps=.5,
                                                  **kwargs):
-    eps = float32(eps)
+    eps = eps
     x_val, x_adv, delta = self.generate_adversarial_examples_np(ord, eps,
                                                                 **kwargs)
     self.assertClose(delta, eps)
@@ -217,7 +216,7 @@ class TestFastGradientMethod(CleverHansTest):
     random_labs_one_hot[np.arange(100), random_labs] = 1
 
     _, x_adv, delta = self.generate_adversarial_examples_np(
-        eps=float32(.5), ord=np.inf, y_target=random_labs_one_hot)
+        eps=.5, ord=np.inf, y_target=random_labs_one_hot)
 
     self.assertClose(delta, 0.5)
 
@@ -231,8 +230,8 @@ class TestFastGradientMethod(CleverHansTest):
     for eps in [0.1, 0.2, 0.3, 0.4]:
       eps = np.array(eps, dtype='float32')
       x_adv = self.attack.generate_np(x_val, eps=eps, ord=np.inf,
-                                      clip_min=float32(-5.0),
-                                      clip_max=float32(5.0))
+                                      clip_min=-5.0,
+                                      clip_max=5.0)
 
       delta = np.max(np.abs(x_adv - x_val), axis=1)
       self.assertClose(delta, eps)
@@ -243,8 +242,8 @@ class TestFastGradientMethod(CleverHansTest):
 
     x_adv = self.attack.generate_np(x_val, eps=np.array(0.5, 'float32'),
                                     ord=np.inf,
-                                    clip_min=float32(-0.2),
-                                    clip_max=float32(0.1))
+                                    clip_min=-0.2,
+                                    clip_max=0.1)
 
     self.assertClose(np.min(x_adv), -0.2)
     self.assertClose(np.max(x_adv), 0.1)
@@ -369,9 +368,9 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=float32(1.0), ord=np.inf,
-                                    clip_min=float32(0.5),
-                                    clip_max=float32(0.7),
+    x_adv = self.attack.generate_np(x_val, eps=1.0, ord=np.inf,
+                                    clip_min=0.5,
+                                    clip_max=0.7,
                                     nb_iter=5)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -382,9 +381,9 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=float32(1.0), ord=np.inf,
-                                    clip_min=float32(-5.0),
-                                    clip_max=float32(5.0),
+    x_adv = self.attack.generate_np(x_val, eps=1.0, ord=np.inf,
+                                    clip_min=-5.0,
+                                    clip_max=5.0,
                                     nb_iter=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -400,9 +399,9 @@ class TestBasicIterativeMethod(TestFastGradientMethod):
 
     tf.gradients = fn
 
-    x_adv = self.attack.generate_np(x_val, eps=float32(1.0), ord=np.inf,
-                                    clip_min=float32(-5.0),
-                                    clip_max=float32(5.0),
+    x_adv = self.attack.generate_np(x_val, eps=1.0, ord=np.inf,
+                                    clip_min=-5.0,
+                                    clip_max=5.0,
                                     nb_iter=11)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -427,10 +426,10 @@ class TestMomentumIterativeMethod(TestBasicIterativeMethod):
     x_val = np.array(x_val, dtype=np.float32)
 
     for decay_factor in [0.0, 0.5, 1.0]:
-      x_adv = self.attack.generate_np(x_val, eps=float32(0.5), ord=np.inf,
+      x_adv = self.attack.generate_np(x_val, eps=0.5, ord=np.inf,
                                       decay_factor=decay_factor,
-                                      clip_min=float32(-5.0),
-                                      clip_max=float32(5.0))
+                                      clip_min=-5.0,
+                                      clip_max=5.0)
 
       delta = np.max(np.abs(x_adv - x_val), axis=1)
       self.assertClose(delta, 0.5)
@@ -451,8 +450,8 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=float32(-5),
-                                    clip_max=float32(5),
+                                    clip_min=-5,
+                                    clip_max=3,
                                     batch_size=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -469,7 +468,7 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=float32(-5), clip_max=float32(5),
+                                    clip_min=-5, clip_max=3,
                                     batch_size=100, y_target=feed_labs)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -491,8 +490,8 @@ class TestCarliniWagnerL2(CleverHansTest):
     x_adv_p = self.attack.generate(x, max_iterations=100,
                                    binary_search_steps=3,
                                    initial_const=1,
-                                   clip_min=float32(-5),
-                                   clip_max=float32(5),
+                                   clip_min=-5,
+                                   clip_max=3,
                                    batch_size=100, y=y)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val, y: feed_labs})
@@ -509,8 +508,8 @@ class TestCarliniWagnerL2(CleverHansTest):
                                     binary_search_steps=1,
                                     learning_rate=1e-3,
                                     initial_const=1,
-                                    clip_min=float32(-0.2),
-                                    clip_max=float32(0.3),
+                                    clip_min=-0.2,
+                                    clip_max=0.3,
                                     batch_size=100)
 
     self.assertTrue(-0.201 < np.min(x_adv))
@@ -532,8 +531,8 @@ class TestCarliniWagnerL2(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=float32(-10),
-                                 clip_max=float32(10),
+                                 clip_min=-10,
+                                 clip_max=10,
                                  confidence=CONFIDENCE,
                                  y_target=feed_labs,
                                  batch_size=10)
@@ -565,7 +564,7 @@ class TestCarliniWagnerL2(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=float32(-10), clip_max=float32(10),
+                                 clip_min=-10, clip_max=10,
                                  confidence=CONFIDENCE,
                                  batch_size=10)
 
@@ -595,8 +594,8 @@ class TestElasticNetMethod(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=float32(-5),
-                                    clip_max=float32(5),
+                                    clip_min=-5,
+                                    clip_max=3,
                                     batch_size=10)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -613,7 +612,7 @@ class TestElasticNetMethod(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=float32(-5), clip_max=float32(5),
+                                    clip_min=-5, clip_max=3,
                                     batch_size=100, y_target=feed_labs)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -635,7 +634,7 @@ class TestElasticNetMethod(CleverHansTest):
     x_adv_p = self.attack.generate(x, max_iterations=100,
                                    binary_search_steps=3,
                                    initial_const=1,
-                                   clip_min=float32(-5), clip_max=float32(5),
+                                   clip_min=-5, clip_max=3,
                                    batch_size=100, y=y)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val, y: feed_labs})
@@ -652,8 +651,8 @@ class TestElasticNetMethod(CleverHansTest):
                                     binary_search_steps=1,
                                     learning_rate=1e-3,
                                     initial_const=1,
-                                    clip_min=float32(-0.2),
-                                    clip_max=float32(0.3),
+                                    clip_min=-0.2,
+                                    clip_max=0.3,
                                     batch_size=100)
 
     self.assertTrue(-0.201 < np.min(x_adv))
@@ -675,7 +674,7 @@ class TestElasticNetMethod(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=float32(-10), clip_max=float32(10),
+                                 clip_min=-10, clip_max=10,
                                  confidence=CONFIDENCE,
                                  y_target=feed_labs,
                                  batch_size=10)
@@ -707,7 +706,7 @@ class TestElasticNetMethod(CleverHansTest):
                                  binary_search_steps=2,
                                  learning_rate=1e-2,
                                  initial_const=1,
-                                 clip_min=float32(-10), clip_max=float32(10),
+                                 clip_min=-10, clip_max=10,
                                  confidence=CONFIDENCE,
                                  batch_size=10)
 
@@ -745,8 +744,8 @@ class TestSaliencyMapMethod(CleverHansTest):
     feed_labs = np.zeros((10, 10), dtype=np.float32)
     feed_labs[np.arange(10), np.random.randint(0, 9, 10)] = 1
     x_adv = self.attack.generate_np(x_val,
-                                    clip_min=float32(-5.),
-                                    clip_max=float32(5.),
+                                    clip_min=-5.,
+                                    clip_max=5.,
                                     y_target=feed_labs)
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
 
@@ -767,8 +766,8 @@ class TestDeepFool(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     x_adv = self.attack.generate_np(x_val, over_shoot=0.02, max_iter=50,
-                                    nb_candidate=2, clip_min=float32(-5),
-                                    clip_max=float32(5))
+                                    nb_candidate=2, clip_min=-5,
+                                    clip_max=3)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -783,7 +782,7 @@ class TestDeepFool(CleverHansTest):
     x = tf.placeholder(tf.float32, x_val.shape)
 
     x_adv_p = self.attack.generate(x, over_shoot=0.02, max_iter=50,
-                                   nb_candidate=2, clip_min=float32(-5), clip_max=float32(5))
+                                   nb_candidate=2, clip_min=-5, clip_max=3)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val})
 
@@ -796,8 +795,8 @@ class TestDeepFool(CleverHansTest):
     x_val = np.array(x_val, dtype=np.float32)
 
     x_adv = self.attack.generate_np(x_val, over_shoot=0.02, max_iter=50,
-                                    nb_candidate=2, clip_min=float32(-0.2),
-                                    clip_max=float32(0.3))
+                                    nb_candidate=2, clip_min=-0.2,
+                                    clip_max=0.3)
 
     self.assertTrue(-0.201 < np.min(x_adv))
     self.assertTrue(np.max(x_adv) < .301)
@@ -820,10 +819,10 @@ class TestMadryEtAl(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=float32(1.0),
-                                    eps_iter=float32(0.05),
-                                    clip_min=float32(0.5),
-                                    clip_max=float32(0.7),
+    x_adv = self.attack.generate_np(x_val, eps=1.0,
+                                    eps_iter=0.05,
+                                    clip_min=0.5,
+                                    clip_max=0.7,
                                     nb_iter=5, sanity_checks=False)
 
     orig_labs = np.argmax(self.sess.run(self.model(x_val)), axis=1)
@@ -834,8 +833,8 @@ class TestMadryEtAl(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=float32(1.0),
-                                    eps_iter=float32(0.1),
+    x_adv = self.attack.generate_np(x_val, eps=1.0,
+                                    eps_iter=0.1,
                                     nb_iter=5)
 
     delta = np.max(np.abs(x_adv - x_val), axis=1)
@@ -845,11 +844,11 @@ class TestMadryEtAl(CleverHansTest):
     x_val = np.random.rand(100, 2)
     x_val = np.array(x_val, dtype=np.float32)
 
-    x_adv = self.attack.generate_np(x_val, eps=float32(1.0),
-                                    eps_iter=float32(0.1),
+    x_adv = self.attack.generate_np(x_val, eps=1.0,
+                                    eps_iter=0.1,
                                     nb_iter=5,
-                                    clip_min=float32(-0.2),
-                                    clip_max=float32(0.3),
+                                    clip_min=-0.2,
+                                    clip_max=0.3,
                                     sanity_checks=False)
 
     self.assertLess(-0.201, np.min(x_adv))
@@ -956,8 +955,8 @@ class TestFastFeatureAdversaries(CleverHansTest):
     x_guide = tf.abs(tf.random_uniform(input_shape, 0., 1.))
 
     layer = 'fc7'
-    attack_params = {'eps': float32(5. / 256), 'clip_min': float32(0.), 'clip_max': 1.,
-                     'nb_iter': 10, 'eps_iter': float32(0.005),
+    attack_params = {'eps': 5. / 256, 'clip_min': 0., 'clip_max': 1.,
+                     'nb_iter': 10, 'eps_iter': 0.005,
                      'layer': layer}
     x_adv = self.attack.generate(x_src, x_guide, **attack_params)
     h_adv = self.model.fprop(x_adv)[layer]
@@ -999,7 +998,7 @@ class TestLBFGS(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=100,
                                     binary_search_steps=3,
                                     initial_const=1,
-                                    clip_min=float32(-5), clip_max=float32(5),
+                                    clip_min=-5, clip_max=3,
                                     batch_size=100, y_target=feed_labs)
 
     new_labs = np.argmax(self.sess.run(self.model(x_adv)), axis=1)
@@ -1019,7 +1018,7 @@ class TestLBFGS(CleverHansTest):
     x_adv_p = self.attack.generate(x, max_iterations=100,
                                    binary_search_steps=3,
                                    initial_const=1,
-                                   clip_min=float32(-5), clip_max=float32(5),
+                                   clip_min=-5, clip_max=3,
                                    batch_size=100, y_target=y)
     self.assertEqual(x_val.shape, x_adv_p.shape)
     x_adv = self.sess.run(x_adv_p, {x: x_val, y: feed_labs})
@@ -1038,7 +1037,7 @@ class TestLBFGS(CleverHansTest):
     x_adv = self.attack.generate_np(x_val, max_iterations=10,
                                     binary_search_steps=1,
                                     initial_const=1,
-                                    clip_min=float32(-0.2), clip_max=float32(0.3),
+                                    clip_min=-0.2, clip_max=0.3,
                                     batch_size=100, y_target=feed_labs)
 
     self.assertTrue(-0.201 < np.min(x_adv))


### PR DESCRIPTION
This fixes issues where we had false cache hits and thus ran the wrong graph when we passed eps=None one one call and then eps=1. or some other value on a later call, or vice versa, or did the same with any other optional parameter, like clip_min, clip_max, etc.

This also fixes issues where generate_np didn't check the type of the arguments / always casted everything to the same dtype. This meant that generate_np and generate would silently behave differently and that it wasn't possible to implement some dtypes (usually float64) with generate_np.

A side benefit of this PR is that it's no longer necessary to declare the type of feedable keyword arguments in the Attack subclass constructor. The types are just inferred from the numpy values when generate_np is called.

The main problem with this PR is that it is a breaking change. Quite a lot of existing client code uses `generate_np` with float64 / int64 variables, relying on undocumented behavior to cast them to float32 / int32.