### PR TITLE
Clip image to be in valid range during first iteration of PGD

### DIFF
--- a/cleverhans/attacks.py
+++ b/cleverhans/attacks.py
@@ -543,11 +543,13 @@ class ProjectedGradientDescent(Attack):
       return tf.less(i, self.nb_iter)
 
     def body(i, e):
-      adv_x = FGM.generate(x + e, **fgm_params)
+      input_adv_x = x + e
 
       # Clipping perturbation according to clip_min and clip_max
       if self.clip_min is not None and self.clip_max is not None:
-        adv_x = tf.clip_by_value(adv_x, self.clip_min, self.clip_max)
+        input_adv_x = tf.clip_by_value(input_adv_x, self.clip_min, self.clip_max)
+
+      adv_x = FGM.generate(input_adv_x, **fgm_params)
 
       # Clipping perturbation eta to self.ord norm ball
       eta = adv_x - x


### PR DESCRIPTION
This is a potential fix for issue [823](https://github.com/tensorflow/cleverhans/issues/823).

_fgm()_ method already does the image clipping before returning the adversarial image, hence I've just moved the clipping to be done before feeding in to the _FGSM.generate()_.  