### PR TITLE
Added missing branch of if statement for script_files in devtools/list_files

### DIFF
--- a/cleverhans/devtools/list_files.py
+++ b/cleverhans/devtools/list_files.py
@@ -47,6 +47,8 @@ def list_files(suffix=""):
     scripts_files = _list_files(scripts_path, suffix)
     scripts_files = [os.path.join(os.pardir, path) for path in
                      scripts_files]
+  else:
+    scripts_files = []
 
   file_list = file_list + tutorials_files + examples_files + scripts_files
 


### PR DESCRIPTION
Fixed minor bug in `devtools/list_files.py` that fails when there are no scripts.

Stack trace from previous version below:
```
>>> import cleverhans
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mikelynch/anaconda3/envs/tf-py/lib/python3.6/site-packages/cleverhans/__init__.py", line 6, in <module>
    __version__ = append_dev_version('2.0.0')
  File "/Users/mikelynch/anaconda3/envs/tf-py/lib/python3.6/site-packages/cleverhans/devtools/version.py", line 32, in append_dev_version
    dev_version_value = dev_version()
  File "/Users/mikelynch/anaconda3/envs/tf-py/lib/python3.6/site-packages/cleverhans/devtools/version.py", line 17, in dev_version
    py_files = sorted(list_files(suffix=".py"))
  File "/Users/mikelynch/anaconda3/envs/tf-py/lib/python3.6/site-packages/cleverhans/devtools/list_files.py", line 51, in list_files
    file_list = file_list + tutorials_files + examples_files + scripts_files
UnboundLocalError: local variable 'scripts_files' referenced before assignment
```