### PR TITLE
tensorflow version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 env:
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.8.0 PYTORCH=False
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.12.0 PYTORCH=False
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.9.0 PYTORCH=True
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.8.0 PYTORCH=True
 
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
@@ -34,11 +34,11 @@ install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.12.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp27-none-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0rc1-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.12.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl;
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0rc1-cp35-cp35m-linux_x86_64.whl;
     fi
 
   - time pip install -q -e ".[test]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.5
 env:
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.8.0 PYTORCH=False
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.9.0 PYTORCH=False
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.12.0 PYTORCH=False
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.9.0 PYTORCH=True
 
 install:
@@ -33,12 +33,12 @@ install:
   # install TensorFlow
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.9.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp27-none-linux_x86_64.whl;
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.12.0" ]]; then
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp27-none-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.9.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp35-cp35m-linux_x86_64.whl;
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.12.0" ]]; then
+      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp35-cp35m-linux_x86_64.whl;
     fi
 
   - time pip install -q -e ".[test]"

--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ pip install -e ./cleverhans
 
 Although CleverHans is likely to work on many other machine configurations, we
 currently [test it](https://travis-ci.org/tensorflow/cleverhans) it with Python
-{2.7, 3.5} and TensorFlow {1.8, 1.9} on Ubuntu 14.04.5 LTS (Trusty Tahr).
-Support for TensorFlow 1.3 and earlier is deprecated. After 2018-11-1 we will
-not fix bugs reported for these versions and we will eliminate wrapper code
-needed for backwards compatibility with these versions.
+{2.7, 3.5} and TensorFlow {1.8, 1.12} on Ubuntu 14.04.5 LTS (Trusty Tahr).
+Support for TensorFlow prior to 1.8 is deprecated.
+Backwards compatibility wrappers for these versions may be removed after
+2019-01-26, and we will not fix bugs for those versions after that date.
+Support for TensorFlow 1.3 and earlier is already deprecated: we do not fix
+bugs for those versions and any remaining wrapper code for those versions
+may be removed without further notice.
 
 ## Getting support
 

--- a/cleverhans/utils_tf.py
+++ b/cleverhans/utils_tf.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from distutils.version import LooseVersion
 import logging
 import math
 import os
@@ -223,13 +222,8 @@ def model_eval(sess, x, y, predictions, X_test=None, Y_test=None,
   if key in _model_eval_cache:
     correct_preds = _model_eval_cache[key]
   else:
-    if LooseVersion(tf.__version__) >= LooseVersion('1.0.0'):
-      correct_preds = tf.equal(tf.argmax(y, axis=-1),
-                               tf.argmax(predictions, axis=-1))
-    else:
-      correct_preds = tf.equal(tf.argmax(y, axis=tf.rank(y) - 1),
-                               tf.argmax(predictions,
-                                         axis=tf.rank(predictions) - 1))
+    correct_preds = tf.equal(tf.argmax(y, axis=-1),
+                             tf.argmax(predictions, axis=-1))
     _model_eval_cache[key] = correct_preds
 
   # Init result var

--- a/cleverhans/utils_tfe.py
+++ b/cleverhans/utils_tfe.py
@@ -6,8 +6,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
-from distutils.version import LooseVersion
 import math
 import os
 import time
@@ -153,10 +151,6 @@ def model_eval(model, X_test=None, Y_test=None, args=None,
   if X_test is None or Y_test is None:
     raise ValueError("X_test argument and Y_test argument "
                      "must be supplied.")
-
-  # Define accuracy symbolically
-  if LooseVersion(tf.__version__) <= LooseVersion('1.0.0'):
-    raise Exception('Use Tensorflow Version greather than 1.0.0')
 
   # Init result var
   accuracy = 0.0


### PR DESCRIPTION
- This updates Travis to test TF version 1.12, so that we're getting the latest version
- It also drops tests for version 1.9. My thinking is that among the versions we still support, we want the greatest spread in our tests.
- This also updates the README to say that support for versions before 1.8 will be dropped in January. There is already a deprecation warning saying this in compat.py, but it wasn't copied to the relevant part of the README before.
- This also removes some wrapper code for versions that are old enough that we already don't support them