### PR TITLE
fix unpickling

### DIFF
--- a/cleverhans/confidence_report.py
+++ b/cleverhans/confidence_report.py
@@ -56,7 +56,16 @@ class ConfidenceReport(OrderedDict):
   This class is just a dictionary with some type checks.
   It maps string data type names (like "clean" for clean data or "Semantic"
   for semantic adversarial examples) to ConfidenceReportEntry instances.
+
+  :param iterable: optional iterable containing (key, value) tuples
   """
+
+  def __init__(self, iterable=None):
+    super(ConfidenceReport, self).__init__()
+    if iterable is not None:
+      # pickle sometimes wants to use this interface to unpickle the OrderedDict
+      for key, value in iterable:
+        self[key] = value
 
   def __setitem__(self, key, value):
     assert isinstance(key, six.string_types)


### PR DESCRIPTION
Some pickle files for ConfidenceReports are broken because OrderedDict wants to use this constructor argument to unpickle itself. I actually haven't figured out what causes it to use this path so I haven't been able to make a unit test for it.