### PR TITLE
Allow for tensorflow_probability to take over from tf.distributions

### DIFF
--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -13,10 +13,9 @@ from cleverhans.model import Model
 from cleverhans.utils import safe_zip
 
 try:
-  import tensorflow_probability as tfp
-  tf_distributions = tfp.distributions
+  import tensorflow_probability.distributions as tf_distributions
 except ImportError:
-  tf_distributions = tf.distributions
+  import tensorflow.distributions as tf_distributions
 
 
 class Loss(object):

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -13,9 +13,10 @@ from cleverhans.model import Model
 from cleverhans.utils import safe_zip
 
 try:
-  import tensorflow_probability.distributions as tf_distributions
+  import tensorflow_probability as tfp
+  tf_distributions = tfp.distributions
 except ImportError:
-  import tensorflow.distributions as tf_distributions
+  tf_distributions = tf.distributions
 
 
 class Loss(object):

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -12,6 +12,12 @@ from cleverhans.compat import softmax_cross_entropy_with_logits
 from cleverhans.model import Model
 from cleverhans.utils import safe_zip
 
+try:
+  import tensorflow_probability as tfp
+  tf_distributions = tfp.distributions
+except AttributeError:
+  tf_distributions = tf.distributions
+
 
 class Loss(object):
   """
@@ -175,7 +181,7 @@ class MixUp(Loss):
   def fprop(self, x, y, **kwargs):
     with tf.device('/CPU:0'):
       # Prevent error complaining GPU kernels unavailable for this.
-      mix = tf.distributions.Beta(self.beta, self.beta)
+      mix = tf_distributions.Beta(self.beta, self.beta)
       mix = mix.sample([tf.shape(x)[0]] + [1] * (len(x.shape) - 1))
     mix = tf.maximum(mix, 1 - mix)
     mix_label = tf.reshape(mix, [-1, 1])
@@ -313,7 +319,7 @@ class LossMixUp(Loss):
     self.beta = beta
 
   def fprop(self, x, y, **kwargs):
-    mix = tf.distributions.Beta(self.beta, self.beta)
+    mix = tf_distributions.Beta(self.beta, self.beta)
     mix = mix.sample([tf.shape(x)[0]] + [1] * (len(x.shape) - 1))
     xm = x + mix * (x[::-1] - x)
     ym = y + mix * (y[::-1] - y)

--- a/cleverhans/loss.py
+++ b/cleverhans/loss.py
@@ -15,7 +15,7 @@ from cleverhans.utils import safe_zip
 try:
   import tensorflow_probability as tfp
   tf_distributions = tfp.distributions
-except AttributeError:
+except ImportError:
   tf_distributions = tf.distributions
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='cleverhans',
           'matplotlib',
           "mnist ~= 0.2",
           "numpy",
+          "tensorflow-probability",
       ],
       # Explicit dependence on TensorFlow is not supported.
       # See https://github.com/tensorflow/tensorflow/issues/7166


### PR DESCRIPTION
`tf.distributions` is being deprecated. This allows for both forward and backwards compatibility.