### PR TITLE
'Update MNIST PyTorch Tutorial to work with PyTorch 1.0.0'

### DIFF
--- a/cleverhans_tutorials/mnist_tutorial_pytorch.py
+++ b/cleverhans_tutorials/mnist_tutorial_pytorch.py
@@ -107,7 +107,7 @@ def mnist_tutorial(nb_epochs=NB_EPOCHS, batch_size=BATCH_SIZE,
       optimizer.step()  # update gradients
 
       preds_np = preds.cpu().detach().numpy()
-      correct += (np.argmax(preds_np, axis=1) == ys.detach().numpy()).sum()
+      correct += (np.argmax(preds_np, axis=1) == ys.cpu().detach().numpy()).sum()
       total += train_loader.batch_size
       step += 1
       if total % 1000 == 0:
@@ -127,7 +127,7 @@ def mnist_tutorial(nb_epochs=NB_EPOCHS, batch_size=BATCH_SIZE,
     preds = torch_model(xs)
     preds_np = preds.cpu().detach().numpy()
 
-    correct += (np.argmax(preds_np, axis=1) == ys.detach().numpy()).sum()
+    correct += (np.argmax(preds_np, axis=1) == ys.cpu().detach().numpy()).sum()
     total += len(xs)
 
   acc = float(correct) / total
@@ -155,7 +155,7 @@ def mnist_tutorial(nb_epochs=NB_EPOCHS, batch_size=BATCH_SIZE,
   correct = 0
   for xs, ys in test_loader:
     adv_preds = sess.run(adv_preds_op, feed_dict={x_op: xs})
-    correct += (np.argmax(adv_preds, axis=1) == ys.detach().numpy()).sum()
+    correct += (np.argmax(adv_preds, axis=1) == ys.cpu().detach().numpy()).sum()
     total += test_loader.batch_size
 
   acc = float(correct) / total

--- a/cleverhans_tutorials/mnist_tutorial_pytorch.py
+++ b/cleverhans_tutorials/mnist_tutorial_pytorch.py
@@ -106,9 +106,9 @@ def mnist_tutorial(nb_epochs=NB_EPOCHS, batch_size=BATCH_SIZE,
       train_loss.append(loss.data.item())
       optimizer.step()  # update gradients
 
-      preds_np = preds.data.cpu().numpy()
-      correct += (np.argmax(preds_np, axis=1) == ys).sum()
-      total += len(xs)
+      preds_np = preds.cpu().detach().numpy()
+      correct += (np.argmax(preds_np, axis=1) == ys.detach().numpy()).sum()
+      total += train_loader.batch_size
       step += 1
       if total % 1000 == 0:
         acc = float(correct) / total
@@ -125,9 +125,9 @@ def mnist_tutorial(nb_epochs=NB_EPOCHS, batch_size=BATCH_SIZE,
       xs, ys = xs.cuda(), ys.cuda()
 
     preds = torch_model(xs)
-    preds_np = preds.data.cpu().numpy()
+    preds_np = preds.cpu().detach().numpy()
 
-    correct += (np.argmax(preds_np, axis=1) == ys).sum()
+    correct += (np.argmax(preds_np, axis=1) == ys.detach().numpy()).sum()
     total += len(xs)
 
   acc = float(correct) / total
@@ -155,8 +155,8 @@ def mnist_tutorial(nb_epochs=NB_EPOCHS, batch_size=BATCH_SIZE,
   correct = 0
   for xs, ys in test_loader:
     adv_preds = sess.run(adv_preds_op, feed_dict={x_op: xs})
-    correct += (np.argmax(adv_preds, axis=1) == ys).sum()
-    total += len(xs)
+    correct += (np.argmax(adv_preds, axis=1) == ys.detach().numpy()).sum()
+    total += test_loader.batch_size
 
   acc = float(correct) / total
   print('Adv accuracy: {:.3f}'.format(acc * 100))


### PR DESCRIPTION
Made a few changes to `cleverhans_tutorials/mnist_tutorial_pytorch.py` which was otherwise running into a `TypeError` as below:

```
Traceback (most recent call last):
  File "mnist_tutorial_pytorch.py", line 184, in <module>
    tf.app.run()
  File "/nobackup/python35/lib/python3.6/site-packages/tensorflow/python/platform/app.py", line 125, in run
    _sys.exit(main(argv))
  File "mnist_tutorial_pytorch.py", line 173, in main
    learning_rate=FLAGS.learning_rate)
  File "mnist_tutorial_pytorch.py", line 110, in mnist_tutorial
    correct += (np.argmax(preds_np, axis=1) == ys).sum()
TypeError: eq() received an invalid combination of arguments - got (numpy.ndarray), but expected one of:
 * (Tensor other)
      didn't match because some of the arguments have invalid types: (numpy.ndarray)
 * (Number other)
      didn't match because some of the arguments have invalid types: (numpy.ndarray)
``` 