### PR TITLE
Drop older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   # exit on first error
   - set -e
   # run keras backend init to initialize backend config
-  - python -c "import keras.backend"
+  - python -c "import tensorflow.keras.backend"
   # create dataset directory to avoid concurrent directory creation at runtime
   - mkdir ~/.keras/datasets
   # set up keras backend

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 language: python
 python:
-  - 2.7
   - 3.5
 env:
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.8.0 PYTORCH=False
@@ -12,13 +11,7 @@ env:
 
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
@@ -31,11 +24,7 @@ install:
   - source activate test-environment
 
   # install TensorFlow
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.8.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.12.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0rc1-cp27-none-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.12.0" ]]; then
       pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0rc1-cp35-cp35m-linux_x86_64.whl;

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Google Inc., OpenAI and Pennsylvania State University
+Copyright (c) 2019 Google Inc., OpenAI and Pennsylvania State University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ pip install -e ./cleverhans
 
 Although CleverHans is likely to work on many other machine configurations, we
 currently [test it](https://travis-ci.org/tensorflow/cleverhans) it with Python
-{2.7, 3.5} and TensorFlow {1.8, 1.12} on Ubuntu 14.04.5 LTS (Trusty Tahr).
+3.5 and TensorFlow {1.8, 1.12} on Ubuntu 14.04.5 LTS (Trusty Tahr).
+Support for Python 2.7 is deprecated.
+CleverHans 3.0.1 supports Python 2.7 and the master branch is likely to
+continue to work in Python 2.7 for some time, but we no longer run the tests
+in Python 2.7 and we do not plan to fix bugs affecting only Python 2.7 after
+2019-07-04.
 Support for TensorFlow prior to 1.8 is deprecated.
 Backwards compatibility wrappers for these versions may be removed after
 2019-01-26, and we will not fix bugs for those versions after that date.

--- a/README.md
+++ b/README.md
@@ -150,14 +150,6 @@ carefully by the adversary. The adversary then uses the substitute
 model’s gradients to find adversarial examples that are misclassified by the
 black-box model as well.
 
-Some models used in the tutorials are defined using [Keras](https://keras.io),
-which should be installed before running these tutorials.
-Installation instructions for Keras can be found
-[here](https://keras.io/#installation).
-Note that you should configure Keras to use the TensorFlow backend. You
-can find instructions for
-setting the Keras backend [on this page](https://keras.io/backend/).
-
 NOTE: the tutorials are maintained carefully, in the sense that we use
 continuous integration to make sure they continue working. They are not
 considered part of the API and they can change at any time without warning.

--- a/cleverhans/devtools/mocks.py
+++ b/cleverhans/devtools/mocks.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 
 import copy
 
-from keras.utils import np_utils
+from tensorflow.python.keras.utils import np_utils
 import numpy as np
 
 from cleverhans.dataset import Dataset

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -1,7 +1,6 @@
 """
 Model construction utilities based on keras
 """
-from distutils.version import LooseVersion
 from tensorflow import keras
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Conv2D, Dense, Activation, Flatten

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -4,11 +4,9 @@ Model construction utilities based on keras
 from distutils.version import LooseVersion
 from tensorflow import keras
 from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Dense, Activation, Flatten
+from tensorflow.keras.layers import Conv2D, Dense, Activation, Flatten
 
 from .model import Model, NoSuchLayerError
-
-from tensorflow.keras.layers import Conv2D
 
 def conv_2d(filters, kernel_shape, strides, padding, input_shape=None):
   """

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -56,9 +56,10 @@ def cnn_model(logits=False, input_ph=None, img_rows=28, img_cols=28,
   model = Sequential()
 
   # Define the layers successively (convolution layers are version dependent)
-  if keras.backend.image_dim_ordering() == 'th':
+  if keras.backend.image_data_format() == 'channels_first':
     input_shape = (channels, img_rows, img_cols)
   else:
+    assert keras.backend.image_data_format() == 'channels_last'
     input_shape = (img_rows, img_cols, channels)
 
   layers = [conv_2d(nb_filters, (8, 8), (2, 2), "same",
@@ -179,7 +180,7 @@ class KerasModelWrapper(Model):
     :return: A dictionary mapping layer names to the symbolic
              representation of their output.
     """
-    from keras.models import Model as KerasModel
+    from tensorflow.keras.models import Model as KerasModel
 
     if self.keras_model is None:
       # Get the input layer

--- a/cleverhans/utils_keras.py
+++ b/cleverhans/utils_keras.py
@@ -2,17 +2,13 @@
 Model construction utilities based on keras
 """
 from distutils.version import LooseVersion
-import keras
-from keras.models import Sequential
-from keras.layers import Dense, Activation, Flatten
+from tensorflow import keras
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Activation, Flatten
 
 from .model import Model, NoSuchLayerError
 
-if LooseVersion(keras.__version__) >= LooseVersion('2.0.0'):
-  from keras.layers import Conv2D
-else:
-  from keras.layers import Convolution2D
-
+from tensorflow.keras.layers import Conv2D
 
 def conv_2d(filters, kernel_shape, strides, padding, input_shape=None):
   """
@@ -31,22 +27,13 @@ def conv_2d(filters, kernel_shape, strides, padding, input_shape=None):
                       layer of the model
   :return: the Keras layer
   """
-  if LooseVersion(keras.__version__) >= LooseVersion('2.0.0'):
-    if input_shape is not None:
-      return Conv2D(filters=filters, kernel_size=kernel_shape,
-                    strides=strides, padding=padding,
-                    input_shape=input_shape)
-    else:
-      return Conv2D(filters=filters, kernel_size=kernel_shape,
-                    strides=strides, padding=padding)
+  if input_shape is not None:
+    return Conv2D(filters=filters, kernel_size=kernel_shape,
+                  strides=strides, padding=padding,
+                  input_shape=input_shape)
   else:
-    if input_shape is not None:
-      return Convolution2D(filters, kernel_shape[0], kernel_shape[1],
-                           subsample=strides, border_mode=padding,
-                           input_shape=input_shape)
-    else:
-      return Convolution2D(filters, kernel_shape[0], kernel_shape[1],
-                           subsample=strides, border_mode=padding)
+    return Conv2D(filters=filters, kernel_size=kernel_shape,
+                  strides=strides, padding=padding)
 
 
 def cnn_model(logits=False, input_ph=None, img_rows=28, img_cols=28,

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -15,7 +15,6 @@ import os
 
 import tensorflow as tf
 from tensorflow import keras
-from tensorflow.keras import backend
 from tensorflow.python.platform import flags
 import numpy as np
 

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -14,10 +14,10 @@ from __future__ import unicode_literals
 import os
 
 import tensorflow as tf
-from tensorflow.python.platform import flags
-import numpy as np
 from tensorflow import keras
 from tensorflow.keras import backend
+from tensorflow.python.platform import flags
+import numpy as np
 
 from cleverhans.attacks import FastGradientMethod
 from cleverhans.dataset import MNIST

--- a/cleverhans_tutorials/mnist_tutorial_keras_tf.py
+++ b/cleverhans_tutorials/mnist_tutorial_keras_tf.py
@@ -16,8 +16,8 @@ import os
 import tensorflow as tf
 from tensorflow.python.platform import flags
 import numpy as np
-import keras
-from keras import backend
+from tensorflow import keras
+from tensorflow.keras import backend
 
 from cleverhans.attacks import FastGradientMethod
 from cleverhans.dataset import MNIST
@@ -59,7 +59,7 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
   :param label_smoothing: float, amount of label smoothing for cross entropy
   :return: an AccuracyReport object
   """
-  keras.layers.core.K.set_learning_phase(0)
+  tf.keras.backend.set_learning_phase(0)
 
   # Object used to keep track of (and return) key accuracies
   report = AccuracyReport()
@@ -67,14 +67,8 @@ def mnist_tutorial(train_start=0, train_end=60000, test_start=0,
   # Set TF random seed to improve reproducibility
   tf.set_random_seed(1234)
 
-  if not hasattr(backend, "tf"):
-    raise RuntimeError("This tutorial requires keras to be configured"
-                       " to use the TensorFlow backend.")
-
-  if keras.backend.image_dim_ordering() != 'tf':
-    keras.backend.set_image_dim_ordering('tf')
-    print("INFO: '~/.keras/keras.json' sets 'image_dim_ordering' to "
-          "'th', temporarily setting to 'tf'")
+  if keras.backend.image_data_format() != 'channels_last':
+    raise NotImplementedError("this tutorial requires keras to be configured to channels_last format")
 
   # Create TF session and set as Keras backend session
   sess = tf.Session()

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ setup(name='cleverhans',
       extras_require={
           "tf": ["tensorflow>=1.0.0"],
           "tf_gpu": ["tensorflow-gpu>=1.0.0"],
-          "test": [
-              "keras == 2.1.5",  # Keras 2.1.6 is incompatible with TF 1.4
-          ],
           "pytorch": ["torch==0.4.0", "torchvision==0.2.1"],
       },
       packages=find_packages())

--- a/tests_tf/test_utils_keras.py
+++ b/tests_tf/test_utils_keras.py
@@ -11,8 +11,8 @@ from cleverhans.utils_keras import KerasModelWrapper
 
 class TestKerasModelWrapper(unittest.TestCase):
   def setUp(self):
-    from keras.models import Sequential
-    from keras.layers import Dense, Activation
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.layers import Dense, Activation
     import tensorflow as tf
 
     def dummy_model():


### PR DESCRIPTION
This drops support for Python 2. It also changes all uses of keras to tensorflow.keras (which exists in all the supported versions of tensorflow) rather than standalone keras.