### PR TITLE
Bapp Corner cases

### DIFF
--- a/cleverhans/attacks/bapp.py
+++ b/cleverhans/attacks/bapp.py
@@ -510,7 +510,7 @@ def geometric_progression_for_stepsize(x, update, dist, decision_function,
   epsilon = dist / np.sqrt(current_iteration)
   while True:
     updated = x + epsilon * update
-    success = decision_function(updated[None])
+    success = decision_function(updated[None])[0]
     if success:
       break
     else:


### PR DESCRIPTION
Fix three corner cases:
  Generate random noise at the scale of clip_min and clip_max.
  Add clip after update to avoid accidental large step sizes in the initial steps.
  Add assertion for the case where random initialization fails.
  
Use the sign of gradient for L-inf Boundary Attack++.