### PR TITLE
Update spsa.py

### DIFF
--- a/cleverhans/future/tf2/attacks/spsa.py
+++ b/cleverhans/future/tf2/attacks/spsa.py
@@ -46,7 +46,7 @@ def spsa(model_fn, x, y, eps, nb_iter, clip_min=None, clip_max=None, targeted=Fa
     """
     logits = model_fn(x)
     loss_multiplier = 1 if targeted else -1
-    return loss_multiplier * margin_logit_loss(logits, label, nb_classes=logits.get_shape()[-1])
+    return loss_multiplier * margin_logit_loss(logits, label, nb_classes=logits.shape[-1])
 
   adv_x = projected_optimization(loss_fn, x, y, eps, nb_iter, optimizer, clip_min, clip_max,
                                  early_stop_loss_threshold, is_debug=is_debug)


### PR DESCRIPTION
Currently, although SPSA attack theoretically works with both differentiable and non-differentiable classifiers, its use with the latter is limited since it expects a TF tensor output. Thus it cannot be tested w/ non-TF classifiers (e.g. random forests, scipy, etc...) which output Numpy arrays instead of TF tensors. This is because line 49 uses logits.get_shape().

To fix this, I propose to sub logits.get_shape to logits.shape since this would generalize to both Numpy arrays and TF tensors. 