### PR TITLE
[tf2] CarliniWagnerL2: Make const shape compatible for batch processing.

### DIFF
--- a/cleverhans/tf2/attacks/carlini_wagner_l2.py
+++ b/cleverhans/tf2/attacks/carlini_wagner_l2.py
@@ -150,7 +150,7 @@ class CarliniWagnerL2(object):
         lower_bound = tf.zeros(shape[:1])
         upper_bound = tf.ones(shape[:1]) * 1e10
 
-        const = tf.ones(shape) * self.initial_const
+        const = tf.ones(shape[:1]) * self.initial_const
 
         # placeholder variables for best values
         best_l2 = tf.fill(shape[:1], 1e10)


### PR DESCRIPTION
Reduce shape of `const` for shape compatibility for batch_size > 1.
Is this as intended for CarliniWagnerL2 and hence a fix for #1205?