### PR TITLE
Update utils.py to fix memory leak in clip_eta function

### DIFF
--- a/cleverhans/torch/utils.py
+++ b/cleverhans/torch/utils.py
@@ -35,7 +35,7 @@ def clip_eta(eta, norm, eps):
         factor = torch.min(
             torch.tensor(1.0, dtype=eta.dtype, device=eta.device), eps / norm
         )
-        eta *= factor
+        eta = eta * factor
     return eta
 
 


### PR DESCRIPTION
Fix memory leak in clip_eta function by removing in-place operations.

This commit addresses a memory leak issue in the clip_eta function located in cleverhans/cleverhans/torch/utils.py. The problem was caused by in-place operations within the function, particularly when modifying the eta tensor. These operations have been replaced with out-of-place equivalents to prevent the accumulation of computational graphs, which was leading to increased memory usage during iterative processes.
